### PR TITLE
Update etikett

### DIFF
--- a/src/main/java/de/hbz/lobid/helper/Etikett.java
+++ b/src/main/java/de/hbz/lobid/helper/Etikett.java
@@ -57,6 +57,12 @@ public class Etikett {
 	String referenceType = "class";
 
 	/**
+	 * Describes if the given is expected to occur as a \@set or a \@list. Can be
+	 * null;
+	 */
+	public String container = null;
+
+	/**
 	 * The jaxb needs this
 	 */
 	public Etikett() {

--- a/src/main/resources/context.json
+++ b/src/main/resources/context.json
@@ -2,575 +2,699 @@
 	"@context":{
 		"extent":{
 			"@id":"http://iflastandards.info/ns/isbd/elements/P1053",
-			"label":"Umfang"
+			"label":"Umfang",
+			"@container":"@set"
 		},
 		"cinematographer":{
 			"@type":"@id",
 			"@id":"http://id.loc.gov/vocabulary/relators/cng",
-			"label":"Kamera"
+			"label":"Kamera",
+			"@container":"@set"
 		},
-		"actor" : {
-			"@id" : "http://id.loc.gov/vocabulary/relators/act",
-			"@type" : "@id",
-			"label" : "Schauspieler/in"
+		"actor":{
+			"@id":"http://id.loc.gov/vocabulary/relators/act",
+			"@type":"@id",
+			"label":"Schauspieler/in",
+			"@container":"@set"
 		},
 		"type":{
 			"@type":"@id",
 			"@id":"http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
-			"label":"Typ"
+			"label":"Typ",
+			"@container":"@set"
 		},
 		"preferredNameForThePlaceOrGeographicName":{
 			"@id":"http://d-nb.info/standards/elementset/gnd#preferredNameForThePlaceOrGeographicName",
-			"label":"Ort"
+			"label":"Ort",
+			"@container":"@set"
 		},
 		"engraver":{
 			"@type":"@id",
 			"@id":"http://id.loc.gov/vocabulary/relators/egr",
-			"label":"Stecher/in"
+			"label":"Stecher/in",
+			"@container":"@set"
 		},
 		"T1008":{
 			"@id":"http://iflastandards.info/ns/isbd/terms/mediatype/T1008",
-			"label":"Kombination"
+			"label":"Kombination",
+			"@container":"@set"
 		},
 		"contributorName":{
 			"@id":"http://purl.org/dc/elements/1.1/contributor",
-			"label":"Mitwirkende"
+			"label":"Mitwirkende",
+			"@container":"@set"
 		},
 		"collaborator":{
 			"@type":"@id",
 			"@id":"http://id.loc.gov/vocabulary/relators/clb",
-			"label":"Mitarbeit"
+			"label":"Mitarbeit",
+			"@container":"@set"
 		},
 		"lccn":{
 			"@id":"http://purl.org/ontology/bibo/lccn",
-			"label":"Lccn"
+			"label":"Lccn",
+			"@container":"@set"
 		},
 		"exemplarOf":{
 			"@type":"@id",
 			"@id":"http://purl.org/vocab/frbr/core#exemplarOf",
-			"label":"Exemplar"
+			"label":"Exemplar",
+			"@container":"@set"
 		},
 		"exemplar":{
 			"@type":"@id",
 			"@id":"http://purl.org/vocab/frbr/core#exemplar",
-			"label":"Exemplar"
+			"label":"Exemplar",
+			"@container":"@set"
 		},
 		"preferredName":{
 			"@id":"http://d-nb.info/standards/elementset/gnd#preferredName",
-			"label":"Name"
+			"label":"Name",
+			"@container":"@set"
 		},
 		"issued":{
 			"@id":"http://purl.org/dc/terms/issued",
-			"label":"Erschienen"
+			"label":"Erschienen",
+			"@container":"@set"
 		},
 		"spatial":{
 			"@type":"@id",
 			"@id":"http://purl.org/dc/terms/spatial",
-			"label":"Ortsbezug"
+			"label":"Ortsbezug",
+			"@container":"@set"
 		},
 		"hbzId":{
 			"icon":"fa fa-bars",
 			"@id":"http://purl.org/lobid/lv#hbzID",
-			"label":"Katalog Id"
+			"label":"Katalog Id",
+			"@container":"@set"
 		},
 		"introductionBy":{
 			"@type":"@id",
 			"@id":"http://id.loc.gov/vocabulary/relators/aui",
-			"label":"Einleitung"
+			"label":"Einleitung",
+			"@container":"@set"
 		},
 		"similar":{
 			"@type":"@id",
 			"@id":"http://umbel.org/umbel#isLike",
-			"label":"Ähnlich zu"
+			"label":"Ähnlich zu",
+			"@container":"@set"
 		},
 		"cartographer":{
 			"@type":"@id",
 			"@id":"http://id.loc.gov/vocabulary/relators/ctg",
-			"label":"Kartographie"
+			"label":"Kartographie",
+			"@container":"@set"
 		},
 		"hasPart":{
 			"@type":"@id",
 			"@id":"http://purl.org/dc/terms/hasPart",
-			"label":"Bestandteile"
+			"label":"Bestandteile",
+			"@container":"@set"
 		},
 		"director":{
 			"@type":"@id",
 			"@id":"http://id.loc.gov/vocabulary/relators/drt",
-			"label":"Regie"
+			"label":"Regie",
+			"@container":"@set"
 		},
 		"eissn":{
 			"@id":"http://purl.org/ontology/bibo/eissn",
-			"label":"Eissn"
+			"label":"Eissn",
+			"@container":"@set"
 		},
 		"isPartOf":{
 			"@type":"@id",
 			"@id":"http://purl.org/dc/terms/isPartOf",
-			"label":"Bestandteil von"
+			"label":"Bestandteil von",
+			"@container":"@set"
 		},
 		"nwbibspatial":{
 			"@type":"@id",
 			"@id":"http://purl.org/lobid/lv#nwbibspatial",
-			"label":"Raumsystematik"
+			"label":"Raumsystematik",
+			"@container":"@set"
 		},
 		"issn":{
 			"@id":"http://purl.org/ontology/bibo/issn",
-			"label":"Issn"
+			"label":"Issn",
+			"@container":"@set"
 		},
 		"preferredNameForThePerson":{
 			"@id":"http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson",
-			"label":"Personenname"
+			"label":"Personenname",
+			"@container":"@set"
 		},
 		"isPartOfName":{
 			"@id":"http://purl.org/dc/elements/1.1/isPartOf",
-			"label":"Bestandteil von"
+			"label":"Bestandteil von",
+			"@container":"@set"
 		},
 		"bibliographicCitation":{
 			"@id":"http://purl.org/dc/terms/bibliographicCitation",
-			"label":"Veröffentlichungs Details"
+			"label":"Veröffentlichungs Details",
+			"@container":"@set"
 		},
 		"doi":{
 			"@id":"http://purl.org/ontology/bibo/doi",
-			"label":"Doi"
+			"label":"Doi",
+			"@container":"@set"
 		},
 		"singer":{
 			"@type":"@id",
 			"@id":"http://id.loc.gov/vocabulary/relators/sng",
-			"label":"Gesang"
+			"label":"Gesang",
+			"@container":"@set"
 		},
 		"contributorList":{
 			"@id":"http://purl.org/ontology/bibo/contributorList",
 			"label":"contributorList",
-			"@container" : "@list",
-			"@type": "@id"
+			"@container":"@list",
+			"@type":"@id"
 		},
 		"dateOfDeath":{
 			"@id":"http://d-nb.info/standards/elementset/gnd#dateOfDeath",
-			"label":"Gestorben am"
+			"label":"Gestorben am",
+			"@container":"@set"
 		},
 		"longitudeAndLatitude":{
 			"@id":"http://rdvocab.info/Elements/longitudeAndLatitude",
-			"label":"Geokoordinaten"
+			"label":"Geokoordinaten",
+			"@container":"@set"
 		},
 		"translator":{
 			"@type":"@id",
 			"@id":"http://purl.org/ontology/bibo/translator",
-			"label":"Übersetzung"
+			"label":"Übersetzung",
+			"@container":"@set"
 		},
 		"creatorName":{
 			"@id":"http://purl.org/dc/elements/1.1/creator",
-			"label":"Autorenname"
+			"label":"Autorenname",
+			"@container":"@set"
 		},
 		"alternativeTitle":{
 			"@id":"http://purl.org/dc/terms/alternative",
-			"label":"Titelzusatz"
+			"label":"Titelzusatz",
+			"@container":"@set"
 		},
 		"fulltextOnline":{
 			"@type":"@id",
 			"@id":"http://purl.org/lobid/lv#fulltextOnline",
-			"label":"Online-Volltext"
+			"label":"Online-Volltext",
+			"@container":"@set"
 		},
 		"volumeIn":{
 			"@type":"@id",
 			"@id":"http://purl.org/lobid/lv#volumeIn",
-			"label":"Gehört zu Band"
+			"label":"Gehört zu Band",
+			"@container":"@set"
 		},
 		"inSeries":{
 			"@type":"@id",
 			"@id":"http://purl.org/lobid/lv#inSeries",
-			"label":"In Reihe"
+			"label":"In Reihe",
+			"@container":"@set"
 		},
 		"zdbId":{
 			"@id":"http://purl.org/lobid/lv#zdbID",
-			"label":"ZdbID"
+			"label":"ZdbID",
+			"@container":"@set"
 		},
 		"wikipedia":{
 			"@type":"@id",
 			"@id":"http://purl.org/ontology/mo/wikipedia",
-			"label":"Wikipedia"
+			"label":"Wikipedia",
+			"@container":"@set"
 		},
 		"hasSupplement":{
 			"@type":"@id",
 			"@id":"http://rdaregistry.info/Elements/u/P60281",
-			"label":"Beilage"
+			"label":"Beilage",
+			"@container":"@set"
 		},
 		"workManifested":{
 			"@type":"@id",
 			"@id":"http://rdvocab.info/RDARelationshipsWEMI/workManifested",
-			"label":"Werkebene"
+			"label":"Werkebene",
+			"@container":"@set"
 		},
 		"musician":{
 			"@type":"@id",
 			"@id":"http://id.loc.gov/vocabulary/relators/mus",
-			"label":"Musik"
+			"label":"Musik",
+			"@container":"@set"
 		},
 		"preferredNameEntityForThePerson":{
 			"@id":"http://d-nb.info/standards/elementset/gnd#preferredNameEntityForThePerson",
-			"label":"Namensentität der Person"
+			"label":"Namensentität der Person",
+			"@container":"@set"
 		},
 		"preferredNameForTheConferenceOrEvent":{
 			"@id":"http://d-nb.info/standards/elementset/gnd#preferredNameForTheConferenceOrEvent",
-			"label":"Konferenzname"
+			"label":"Konferenzname",
+			"@container":"@set"
 		},
 		"hasFormat":{
 			"@type":"@id",
 			"@id":"http://purl.org/dc/terms/hasFormat",
-			"label":"Hat Format"
+			"label":"Hat Format",
+			"@container":"@set"
 		},
 		"editor":{
 			"@type":"@id",
 			"@id":"http://purl.org/ontology/bibo/editor",
-			"label":"Herausgeber/in"
+			"label":"Herausgeber/in",
+			"@container":"@set"
 		},
 		"creator":{
 			"@type":"@id",
 			"@id":"http://purl.org/dc/terms/creator",
-			"label":"Autor"
+			"label":"Autor",
+			"@container":"@set"
 		},
 		"performer":{
 			"@type":"@id",
 			"@id":"http://id.loc.gov/vocabulary/relators/prf",
-			"label":"Interpret"
+			"label":"Interpret",
+			"@container":"@set"
 		},
 		"composer":{
 			"@type":"@id",
 			"@id":"http://id.loc.gov/vocabulary/relators/cmp",
-			"label":"Komponist"
+			"label":"Komponist",
+			"@container":"@set"
 		},
 		"dateOfBirth":{
 			"@id":"http://d-nb.info/standards/elementset/gnd#dateOfBirth",
-			"label":"Geboren am"
+			"label":"Geboren am",
+			"@container":"@set"
 		},
 		"abstract":{
 			"@id":"http://purl.org/dc/terms/abstract",
-			"label":"Inhaltsangabe"
+			"label":"Inhaltsangabe",
+			"@container":"@set"
 		},
 		"conductor":{
 			"@type":"@id",
 			"@id":"http://id.loc.gov/vocabulary/relators/cnd",
-			"label":"Dirigent/in"
+			"label":"Dirigent/in",
+			"@container":"@set"
 		},
 		"otherTitleInformation":{
 			"@id":"http://rdvocab.info/Elements/otherTitleInformation",
-			"label":"Titelzusatz"
+			"label":"Titelzusatz",
+			"@container":"@set"
 		},
 		"urn":{
 			"icon":"fa fa-exchange",
 			"@id":"http://purl.org/lobid/lv#urn",
-			"label":"Urn"
+			"label":"Urn",
+			"@container":"@set"
 		},
 		"afterwordBy":{
 			"@type":"@id",
 			"@id":"http://id.loc.gov/vocabulary/relators/aft",
-			"label":"Autor des Nachwortes"
+			"label":"Autor des Nachwortes",
+			"@container":"@set"
 		},
 		"subjectLocation":{
 			"@id":"http://purl.org/lobid/lv#subjectLocation",
-			"label":"Geokoordinaten"
+			"label":"Geokoordinaten",
+			"@container":"@set"
 		},
 		"callNumber":{
 			"@id":"http://purl.org/ontology/daia/label",
-			"label":"Signatur"
+			"label":"Signatur",
+			"@container":"@set"
 		},
 		"series":{
 			"@type":"@id",
 			"@id":"http://purl.org/lobid/lv#series",
-			"label":"Reihe"
+			"label":"Reihe",
+			"@container":"@set"
 		},
 		"placeOfPublication":{
 			"icon":"fa fa-location-arrow",
 			"@id":"http://rdvocab.info/Elements/placeOfPublication",
-			"label":"Ort der Herausgabe"
+			"label":"Ort der Herausgabe",
+			"@container":"@set"
 		},
 		"thesisInformation":{
 			"@id":"http://rdaregistry.info/Elements/u/P60489",
-			"label":"Hochschulschriftenvermerk"
+			"label":"Hochschulschriftenvermerk",
+			"@container":"@set"
 		},
 		"describedby":{
 			"@type":"@id",
 			"@id":"http://www.w3.org/2007/05/powder-s#describedby",
-			"label":"Beschrieben durch"
+			"label":"Beschrieben durch",
+			"@container":"@set"
 		},
 		"ismn":{
 			"@id":"http://purl.org/ontology/mo/ismn",
-			"label":"Ismn"
+			"label":"Ismn",
+			"@container":"@set"
 		},
 		"isFormatOf":{
 			"@type":"@id",
 			"@id":"http://purl.org/dc/terms/isFormatOf",
-			"label":"Format von"
+			"label":"Format von",
+			"@container":"@set"
 		},
 		"inDataset":{
 			"@type":"@id",
 			"@id":"http://www.w3.org/2000/01/rdf-schema#inDataset",
-			"label":"Gehört zu Datenset"
+			"label":"Gehört zu Datenset",
+			"@container":"@set"
 		},
 		"subject":{
 			"@type":"@id",
 			"icon":"fa fa-tag",
 			"@id":"http://purl.org/dc/terms/subject",
-			"label":"Schlagwort"
+			"label":"Schlagwort",
+			"@container":"@set"
 		},
 		"titleKeyword":{
 			"@id":"http://purl.org/lobid/lv#titleKeyword",
-			"label":"Titelschlagwort"
+			"label":"Titelschlagwort",
+			"@container":"@set"
 		},
 		"language":{
 			"@type":"@id",
 			"@id":"http://purl.org/dc/terms/language",
-			"label":"Sprache"
+			"label":"Sprache",
+			"@container":"@set"
 		},
 		"source":{
 			"@id":"http://purl.org/dc/terms/source",
-			"label":"Quelle"
+			"label":"Quelle",
+			"@container":"@set"
 		},
 		"shortTitle":{
 			"@id":"http://purl.org/ontology/bibo/shortTitle",
-			"label":"Kurztitel"
+			"label":"Kurztitel",
+			"@container":"@set"
 		},
 		"subjectChain":{
 			"@id":"http://purl.org/lobid/lv#subjectChain",
-			"label":"Schlagwortkette"
+			"label":"Schlagwortkette",
+			"@container":"@set"
 		},
 		"frequency":{
 			"@id":"http://rdvocab.info/Elements/frequency",
-			"label":"Erscheinungsweise"
+			"label":"Erscheinungsweise",
+			"@container":"@set"
 		},
 		"preferredNameForTheSubjectHeading":{
 			"@id":"http://d-nb.info/standards/elementset/gnd#preferredNameForTheSubjectHeading",
-			"label":"Schlagwort"
+			"label":"Schlagwort",
+			"@container":"@set"
 		},
 		"contributingCorporateBodyLabel":{
 			"@id":"http://purl.org/lobid/lv#nameOfContributingCorporateBody",
-			"label":"Körperschaftsname"
+			"label":"Körperschaftsname",
+			"@container":"@set"
 		},
 		"containedIn":{
 			"@type":"@id",
 			"@id":"http://purl.org/lobid/lv#containedIn",
-			"label":"Enthalten in"
+			"label":"Enthalten in",
+			"@container":"@set"
 		},
 		"isPrimaryTopicOf":{
 			"@type":"@id",
 			"@id":"http://xmlns.com/foaf/0.1/isPrimaryTopicOf",
-			"label":"Weitere Informationen"
+			"label":"Weitere Informationen",
+			"@container":"@set"
 		},
 		"contributorLabel":{
 			"@id":"http://purl.org/lobid/lv#contributorLabel",
-			"label":"Mitwirkende"
+			"label":"Mitwirkende",
+			"@container":"@set"
 		},
 		"publicationStatement":{
 			"@id":"http://rdvocab.info/Elements/publicationStatement",
-			"label":"Erscheinungsort und -jahr"
+			"label":"Erscheinungsort und -jahr",
+			"@container":"@set"
 		},
 		"numbering":{
 			"@id":"http://purl.org/lobid/lv#numbering",
-			"label":"Nummer"
+			"label":"Nummer",
+			"@container":"@set"
 		},
 		"subjectOrder":{
 			"@id":"http://purl.org/lobid/lv#subjectOrder",
 			"label":"subjectOrdered",
-			"@container" : "@list"
+			"@container":"@list"
 		},
 		"dateCreated":{
 			"@id":"http://purl.org/dc/terms/created",
-			"label":"Erstellt am"
+			"label":"Erstellt am",
+			"@container":"@set"
 		},
 		"statementOfResponsibility":{
 			"@id":"http://rdvocab.info/Elements/statementOfResponsibility",
-			"label":"Verantwortlich"
+			"label":"Verantwortlich",
+			"@container":"@set"
 		},
 		"volume":{
 			"@type":"@id",
 			"@id":"http://purl.org/ontology/bibo/volume",
-			"label":"Band"
+			"label":"Band",
+			"@container":"@set"
 		},
 		"primaryTopic":{
 			"@type":"@id",
 			"@id":"http://xmlns.com/foaf/0.1/primaryTopic",
-			"label":"Beschreibt"
+			"label":"Beschreibt",
+			"@container":"@set"
 		},
 		"redaktor":{
 			"@type":"@id",
 			"@id":"http://id.loc.gov/vocabulary/relators/red",
-			"label":"Redaktor"
+			"label":"Redaktor",
+			"@container":"@set"
 		},
 		"producer":{
 			"@type":"@id",
 			"@id":"http://id.loc.gov/vocabulary/relators/pro",
-			"label":"Produzent"
+			"label":"Produzent",
+			"@container":"@set"
 		},
 		"publisher":{
 			"@id":"http://purl.org/dc/elements/1.1/publisher",
-			"label":"Herausgeber"
+			"label":"Herausgeber",
+			"@container":"@set"
 		},
 		"tableOfContents":{
 			"@type":"@id",
 			"icon":"fa fa-list",
 			"@id":"http://purl.org/dc/terms/tableOfContents",
-			"label":"Inhaltsverzeichnis"
+			"label":"Inhaltsverzeichnis",
+			"@container":"@set"
 		},
 		"dedicatee":{
 			"@type":"@id",
 			"@id":"http://id.loc.gov/vocabulary/relators/dte",
-			"label":"Gewidmet"
+			"label":"Gewidmet",
+			"@container":"@set"
 		},
 		"honoree":{
 			"@type":"@id",
 			"@id":"http://id.loc.gov/vocabulary/relators/hnr",
-			"label":"Gefeierte Person"
+			"label":"Gefeierte Person",
+			"@container":"@set"
 		},
 		"oclcnum":{
 			"@id":"http://purl.org/ontology/bibo/oclcnum",
-			"label":"Oclc"
+			"label":"Oclc",
+			"@container":"@set"
 		},
 		"multiVolumeWork":{
 			"@type":"@id",
 			"@id":"http://purl.org/lobid/lv#multiVolumeWork",
-			"label":"Mehrbändiges Werk"
+			"label":"Mehrbändiges Werk",
+			"@container":"@set"
 		},
 		"note":{
 			"@id":"http://www.w3.org/2004/02/skos/core#note",
-			"label":"Hinweis"
+			"label":"Hinweis",
+			"@container":"@set"
 		},
 		"preferredNameForTheCorporateBody":{
 			"@id":"http://d-nb.info/standards/elementset/gnd#preferredNameForTheCorporateBody",
-			"label":"Bevorzugter Körperschaftsname"
+			"label":"Bevorzugter Körperschaftsname",
+			"@container":"@set"
 		},
 		"isSupplementTo":{
 			"@id":"http://rdaregistry.info/Elements/u/P60259",
-			"label":"Beilage zu"
+			"label":"Beilage zu",
+			"@container":"@set"
 		},
 		"hasVersion":{
 			"@type":"@id",
 			"@id":"http://purl.org/dc/terms/hasVersion",
-			"label":"Vgl."
+			"label":"Vgl.",
+			"@container":"@set"
 		},
 		"isbn":{
 			"@id":"http://purl.org/ontology/bibo/isbn",
-			"label":"Isbn"
+			"label":"Isbn",
+			"@container":"@set"
 		},
 		"xsd":{
 			"@id":"http://www.w3.org/2001/XMLSchema#",
-			"label":"XML Schema"
+			"label":"XML Schema",
+			"@container":"@set"
 		},
 		"description":{
 			"@id":"http://purl.org/dc/terms/description",
-			"label":"Beschreibung"
+			"label":"Beschreibung",
+			"@container":"@set"
 		},
 		"edition":{
 			"@id":"http://purl.org/ontology/bibo/edition",
-			"label":"Auflage"
+			"label":"Auflage",
+			"@container":"@set"
 		},
 		"medium":{
 			"@type":"@id",
 			"@id":"http://purl.org/dc/terms/medium",
-			"label":"Träger"
+			"label":"Träger",
+			"@container":"@set"
 		},
 		"title":{
 			"@id":"http://purl.org/dc/terms/title",
-			"label":"Titel"
+			"label":"Titel",
+			"@container":"@set"
 		},
 		"collector":{
 			"@type":"@id",
 			"@id":"http://id.loc.gov/vocabulary/relators/col",
-			"label":"Sammler/in"
+			"label":"Sammler/in",
+			"@container":"@set"
 		},
 		"seeAlso":{
 			"@type":"@id",
 			"@id":"http://www.w3.org/2000/01/rdf-schema#seeAlso",
-			"label":"Weitere Informationen"
+			"label":"Weitere Informationen",
+			"@container":"@set"
 		},
 		"contributor":{
 			"@type":"@id",
 			"@id":"http://purl.org/dc/terms/contributor",
-			"label":"Mitwirkende"
+			"label":"Mitwirkende",
+			"@container":"@set"
 		},
 		"photographer":{
 			"@type":"@id",
 			"@id":"http://id.loc.gov/vocabulary/relators/pht",
-			"label":"Fotografie"
+			"label":"Fotografie",
+			"@container":"@set"
 		},
 		"subjectLabel":{
 			"@id":"http://purl.org/lobid/lv#subjectLabel",
-			"label":"Schlagwort"
+			"label":"Schlagwort",
+			"@container":"@set"
 		},
 		"subjectName":{
 			"@id":"http://purl.org/dc/elements/1.1/subject",
-			"label":"Schlagwort"
+			"label":"Schlagwort",
+			"@container":"@set"
 		},
 		"screenwriter":{
 			"@type":"@id",
 			"@id":"http://id.loc.gov/vocabulary/relators/aus",
-			"label":"Drehbuch"
+			"label":"Drehbuch",
+			"@container":"@set"
 		},
 		"interviewer":{
 			"@type":"@id",
 			"@id":"http://id.loc.gov/vocabulary/relators/ivr",
-			"label":"Interviewer/in"
+			"label":"Interviewer/in",
+			"@container":"@set"
 		},
 		"coverage":{
 			"@id":"http://purl.org/dc/elements/1.1/coverage",
-			"label":"Raumsystematik"
+			"label":"Raumsystematik",
+			"@container":"@set"
 		},
 		"owner":{
 			"@type":"@id",
 			"@id":"http://purl.org/vocab/frbr/core#owner",
-			"label":"Besitz"
+			"label":"Besitz",
+			"@container":"@set"
 		},
 		"preferredNameForTheWork":{
 			"@id":"http://d-nb.info/standards/elementset/gnd#preferredNameForTheWork",
-			"label":"Werkname"
+			"label":"Werkname",
+			"@container":"@set"
 		},
 		"contributor_":{
 			"@type":"@id",
 			"@id":"http://id.loc.gov/vocabulary/relators/ctb",
-			"label":"Mitwirkende"
+			"label":"Mitwirkende",
+			"@container":"@set"
 		},
 		"prefLabel":{
 			"@id":"http://www.w3.org/2004/02/skos/core#prefLabel",
-			"label":"Etikett"
+			"label":"Etikett",
+			"@container":"@set"
 		},
 		"webPageArchived":{
 			"@type":"@id",
 			"@id":"http://purl.org/lobid/lv#webPageArchived",
-			"label":"Archivierte Webseite"
+			"label":"Archivierte Webseite",
+			"@container":"@set"
 		},
 		"dateModified":{
 			"@id":"http://purl.org/dc/terms/modified",
-			"label":"Zuletzt bearbeitet"
+			"label":"Zuletzt bearbeitet",
+			"@container":"@set"
 		},
 		"nwbibsubject":{
 			"@type":"@id",
 			"@id":"http://purl.org/lobid/lv#nwbibsubject",
-			"label":"Sachsystematik"
+			"label":"Sachsystematik",
+			"@container":"@set"
 		},
 		"interviewee":{
 			"@type":"@id",
 			"@id":"http://id.loc.gov/vocabulary/relators/ive",
-			"label":"Interviewte/r"
+			"label":"Interviewte/r",
+			"@container":"@set"
 		},
 		"isDescribedBy":{
 			"@type":"@id",
 			"@id":"http://www.openarchives.org/ore/terms/isDescribedBy",
-			"label":"Beschrieben durch"
+			"label":"Beschrieben durch",
+			"@container":"@set"
 		},
 		"collectedBy":{
 			"@type":"@id",
 			"@id":"http://purl.org/ontology/holding#collectedBy",
-			"label":"Gesammelt von"
+			"label":"Gesammelt von",
+			"@container":"@set"
 		},
 		"preferredNameForTheFamily":{
 			"@id":"http://d-nb.info/standards/elementset/gnd#preferredNameForTheFamily",
-			"label":"Familienname"
+			"label":"Familienname",
+			"@container":"@set"
 		},
 		"illustrator":{
 			"@type":"@id",
 			"@id":"http://id.loc.gov/vocabulary/relators/ill",
-			"label":"Illustration"
+			"label":"Illustration",
+			"@container":"@set"
 		},
 		"sameAs":{
 			"@type":"@id",
 			"@id":"http://www.w3.org/2002/07/owl#sameAs",
-			"label":"Identisch zu"
+			"label":"Identisch zu",
+			"@container":"@set"
 		}
+		
 	}
 }

--- a/src/main/resources/labels.json
+++ b/src/main/resources/labels.json
@@ -1,75 +1,80 @@
 [
 	{
-		"name":"actor",
-		"uri":"http://id.loc.gov/vocabulary/relators/act",
-		"referenceType":"@id",
-		"label":"Schauspieler/in"
-	},
-	{
 		"uri":"http://d-nb.info/standards/elementset/gnd#dateOfBirth",
 		"label":"Geboren am",
 		"name":"dateOfBirth",
-		"referenceType":"String"
+		"referenceType":"String",
+		"container":"@set"
 	},
 	{
 		"uri":"http://d-nb.info/standards/elementset/gnd#dateOfDeath",
 		"label":"Gestorben am",
 		"name":"dateOfDeath",
-		"referenceType":"String"
+		"referenceType":"String",
+		"container":"@set"
 	},
 	{
 		"uri":"http://d-nb.info/standards/elementset/gnd#preferredName",
 		"label":"Name",
 		"name":"preferredName",
-		"referenceType":"String"
+		"referenceType":"String",
+		"container":"@set"
 	},
 	{
 		"uri":"http://d-nb.info/standards/elementset/gnd#preferredNameEntityForThePerson",
 		"label":"Namensentität der Person",
 		"name":"preferredNameEntityForThePerson",
-		"referenceType":"String"
+		"referenceType":"String",
+		"container":"@set"
 	},
 	{
 		"uri":"http://d-nb.info/standards/elementset/gnd#preferredNameForTheConferenceOrEvent",
 		"label":"Konferenzname",
 		"name":"preferredNameForTheConferenceOrEvent",
-		"referenceType":"String"
+		"referenceType":"String",
+		"container":"@set"
 	},
 	{
 		"uri":"http://d-nb.info/standards/elementset/gnd#preferredNameForTheCorporateBody",
 		"label":"Bevorzugter Körperschaftsname",
 		"name":"preferredNameForTheCorporateBody",
-		"referenceType":"String"
+		"referenceType":"String",
+		"container":"@set"
 	},
 	{
 		"uri":"http://d-nb.info/standards/elementset/gnd#preferredNameForTheFamily",
 		"label":"Familienname",
 		"name":"preferredNameForTheFamily",
-		"referenceType":"String"
+		"referenceType":"String",
+		"container":"@set"
 	},
 	{
 		"uri":"http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson",
 		"label":"Personenname",
 		"name":"preferredNameForThePerson",
-		"referenceType":"String"
+		"referenceType":"String",
+		"container":"@set"
 	},
 	{
 		"uri":"http://d-nb.info/standards/elementset/gnd#preferredNameForThePlaceOrGeographicName",
 		"label":"Ort",
 		"name":"preferredNameForThePlaceOrGeographicName",
-		"referenceType":"String"
+		"referenceType":"String",
+		"container":"@set"
 	},
 	{
 		"uri":"http://d-nb.info/standards/elementset/gnd#preferredNameForTheSubjectHeading",
 		"label":"Schlagwort",
 		"name":"preferredNameForTheSubjectHeading",
-		"referenceType":"String"
+		"referenceType":"String",
+		"container":"@set"
 	},
 	{
 		"uri":"http://d-nb.info/standards/elementset/gnd#preferredNameForTheWork",
 		"label":"Werkname",
 		"name":"preferredNameForTheWork",
-		"referenceType":"String"
+		"referenceType":"String",
+		"container":"@set"
 	},
 	{
 		"uri":"http://dewey.info/class/0/",
@@ -5622,446 +5627,519 @@
 		"referenceType":"class"
 	},
 	{
+		"uri":"http://id.loc.gov/vocabulary/relators/act",
+		"label":"Schauspieler/in",
+		"name":"actor",
+		"referenceType":"@id",
+		"container":"@set"
+	},
+	{
 		"uri":"http://id.loc.gov/vocabulary/relators/aft",
 		"label":"Autor des Nachwortes",
 		"name":"afterwordBy",
-		"referenceType":"@id"
+		"referenceType":"@id",
+		"container":"@set"
 	},
 	{
 		"uri":"http://id.loc.gov/vocabulary/relators/aui",
 		"label":"Einleitung",
 		"name":"introductionBy",
-		"referenceType":"@id"
+		"referenceType":"@id",
+		"container":"@set"
 	},
 	{
 		"uri":"http://id.loc.gov/vocabulary/relators/aus",
 		"label":"Drehbuch",
 		"name":"screenwriter",
-		"referenceType":"@id"
+		"referenceType":"@id",
+		"container":"@set"
 	},
 	{
 		"uri":"http://id.loc.gov/vocabulary/relators/clb",
 		"label":"Mitarbeit",
 		"name":"collaborator",
-		"referenceType":"@id"
+		"referenceType":"@id",
+		"container":"@set"
 	},
 	{
 		"uri":"http://id.loc.gov/vocabulary/relators/cmp",
 		"label":"Komponist",
 		"name":"composer",
-		"referenceType":"@id"
+		"referenceType":"@id",
+		"container":"@set"
 	},
 	{
 		"uri":"http://id.loc.gov/vocabulary/relators/cnd",
 		"label":"Dirigent/in",
 		"name":"conductor",
-		"referenceType":"@id"
+		"referenceType":"@id",
+		"container":"@set"
 	},
 	{
 		"uri":"http://id.loc.gov/vocabulary/relators/cng",
 		"label":"Kamera",
 		"name":"cinematographer",
-		"referenceType":"@id"
+		"referenceType":"@id",
+		"container":"@set"
 	},
 	{
 		"uri":"http://id.loc.gov/vocabulary/relators/col",
 		"label":"Sammler/in",
 		"name":"collector",
-		"referenceType":"@id"
+		"referenceType":"@id",
+		"container":"@set"
 	},
 	{
 		"uri":"http://id.loc.gov/vocabulary/relators/ctb",
 		"label":"Mitwirkende",
 		"name":"contributor_",
-		"referenceType":"@id"
+		"referenceType":"@id",
+		"container":"@set"
 	},
 	{
 		"uri":"http://id.loc.gov/vocabulary/relators/ctg",
 		"label":"Kartographie",
 		"name":"cartographer",
-		"referenceType":"@id"
+		"referenceType":"@id",
+		"container":"@set"
 	},
 	{
 		"uri":"http://id.loc.gov/vocabulary/relators/drt",
 		"label":"Regie",
 		"name":"director",
-		"referenceType":"@id"
+		"referenceType":"@id",
+		"container":"@set"
 	},
 	{
 		"uri":"http://id.loc.gov/vocabulary/relators/dte",
 		"label":"Gewidmet",
 		"name":"dedicatee",
-		"referenceType":"@id"
+		"referenceType":"@id",
+		"container":"@set"
 	},
 	{
 		"uri":"http://id.loc.gov/vocabulary/relators/egr",
 		"label":"Stecher/in",
 		"name":"engraver",
-		"referenceType":"@id"
+		"referenceType":"@id",
+		"container":"@set"
 	},
 	{
 		"uri":"http://id.loc.gov/vocabulary/relators/hnr",
 		"label":"Gefeierte Person",
 		"name":"honoree",
-		"referenceType":"@id"
+		"referenceType":"@id",
+		"container":"@set"
 	},
 	{
 		"uri":"http://id.loc.gov/vocabulary/relators/ill",
 		"label":"Illustration",
 		"name":"illustrator",
-		"referenceType":"@id"
+		"referenceType":"@id",
+		"container":"@set"
 	},
 	{
 		"uri":"http://id.loc.gov/vocabulary/relators/ive",
 		"label":"Interviewte/r",
 		"name":"interviewee",
-		"referenceType":"@id"
+		"referenceType":"@id",
+		"container":"@set"
 	},
 	{
 		"uri":"http://id.loc.gov/vocabulary/relators/ivr",
 		"label":"Interviewer/in",
 		"name":"interviewer",
-		"referenceType":"@id"
+		"referenceType":"@id",
+		"container":"@set"
 	},
 	{
 		"uri":"http://id.loc.gov/vocabulary/relators/mus",
 		"label":"Musik",
 		"name":"musician",
-		"referenceType":"@id"
+		"referenceType":"@id",
+		"container":"@set"
 	},
 	{
 		"uri":"http://id.loc.gov/vocabulary/relators/pht",
 		"label":"Fotografie",
 		"name":"photographer",
-		"referenceType":"@id"
+		"referenceType":"@id",
+		"container":"@set"
 	},
 	{
 		"uri":"http://id.loc.gov/vocabulary/relators/prf",
 		"label":"Interpret",
 		"name":"performer",
-		"referenceType":"@id"
+		"referenceType":"@id",
+		"container":"@set"
 	},
 	{
 		"uri":"http://id.loc.gov/vocabulary/relators/pro",
 		"label":"Produzent",
 		"name":"producer",
-		"referenceType":"@id"
+		"referenceType":"@id",
+		"container":"@set"
 	},
 	{
 		"uri":"http://id.loc.gov/vocabulary/relators/red",
 		"label":"Redaktor",
 		"name":"redaktor",
-		"referenceType":"@id"
+		"referenceType":"@id",
+		"container":"@set"
 	},
 	{
 		"uri":"http://id.loc.gov/vocabulary/relators/sng",
 		"label":"Gesang",
 		"name":"singer",
-		"referenceType":"@id"
+		"referenceType":"@id",
+		"container":"@set"
 	},
 	{
 		"uri":"http://iflastandards.info/ns/isbd/elements/P1053",
 		"label":"Umfang",
 		"name":"extent",
-		"referenceType":"String"
+		"referenceType":"String",
+		"container":"@set"
 	},
 	{
 		"uri":"http://iflastandards.info/ns/isbd/terms/mediatype/T1008",
 		"label":"Kombination",
 		"name":"T1008",
-		"referenceType":"String"
+		"referenceType":"String",
+		"container":"@set"
 	},
 	{
 		"uri":"http://purl.org/dc/elements/1.1/contributor",
 		"label":"Mitwirkende",
 		"name":"contributorName",
-		"referenceType":"String"
+		"referenceType":"String",
+		"container":"@set"
 	},
 	{
 		"uri":"http://purl.org/dc/elements/1.1/coverage",
 		"label":"Raumsystematik",
 		"name":"coverage",
-		"referenceType":"String"
+		"referenceType":"String",
+		"container":"@set"
 	},
 	{
 		"uri":"http://purl.org/dc/elements/1.1/creator",
 		"label":"Autorenname",
 		"name":"creatorName",
-		"referenceType":"String"
+		"referenceType":"String",
+		"container":"@set"
 	},
 	{
 		"uri":"http://purl.org/dc/elements/1.1/isPartOf",
 		"label":"Bestandteil von",
 		"name":"isPartOfName",
-		"referenceType":"String"
+		"referenceType":"String",
+		"container":"@set"
 	},
 	{
 		"uri":"http://purl.org/dc/elements/1.1/publisher",
 		"label":"Herausgeber",
 		"name":"publisher",
-		"referenceType":"String"
+		"referenceType":"String",
+		"container":"@set"
 	},
 	{
 		"uri":"http://purl.org/dc/elements/1.1/subject",
 		"label":"Schlagwort",
 		"name":"subjectName",
-		"referenceType":"String"
+		"referenceType":"String",
+		"container":"@set"
 	},
 	{
 		"uri":"http://purl.org/dc/terms/abstract",
 		"label":"Inhaltsangabe",
 		"name":"abstract",
-		"referenceType":"String"
+		"referenceType":"String",
+		"container":"@set"
 	},
 	{
 		"uri":"http://purl.org/dc/terms/alternative",
 		"label":"Titelzusatz",
 		"name":"alternativeTitle",
-		"referenceType":"String"
+		"referenceType":"String",
+		"container":"@set"
 	},
 	{
 		"uri":"http://purl.org/dc/terms/bibliographicCitation",
 		"label":"Veröffentlichungs Details",
 		"name":"bibliographicCitation",
-		"referenceType":"String"
+		"referenceType":"String",
+		"container":"@set"
 	},
 	{
 		"uri":"http://purl.org/dc/terms/contributor",
 		"label":"Mitwirkende",
 		"name":"contributor",
-		"referenceType":"@id"
+		"referenceType":"@id",
+		"container":"@set"
 	},
 	{
 		"uri":"http://purl.org/dc/terms/created",
 		"label":"Erstellt am",
 		"name":"dateCreated",
-		"referenceType":"String"
+		"referenceType":"String",
+		"container":"@set"
 	},
 	{
 		"uri":"http://purl.org/dc/terms/creator",
 		"label":"Autor",
 		"name":"creator",
-		"referenceType":"@id"
+		"referenceType":"@id",
+		"container":"@set"
 	},
 	{
 		"uri":"http://purl.org/dc/terms/description",
 		"label":"Beschreibung",
 		"name":"description",
-		"referenceType":"String"
+		"referenceType":"String",
+		"container":"@set"
 	},
 	{
 		"uri":"http://purl.org/dc/terms/hasFormat",
 		"label":"Hat Format",
 		"name":"hasFormat",
-		"referenceType":"@id"
+		"referenceType":"@id",
+		"container":"@set"
 	},
 	{
 		"uri":"http://purl.org/dc/terms/hasPart",
 		"label":"Bestandteile",
 		"name":"hasPart",
-		"referenceType":"@id"
+		"referenceType":"@id",
+		"container":"@set"
 	},
 	{
 		"uri":"http://purl.org/dc/terms/hasVersion",
 		"label":"Vgl.",
 		"name":"hasVersion",
-		"referenceType":"@id"
+		"referenceType":"@id",
+		"container":"@set"
 	},
 	{
 		"uri":"http://purl.org/dc/terms/isFormatOf",
 		"label":"Format von",
 		"name":"isFormatOf",
-		"referenceType":"@id"
+		"referenceType":"@id",
+		"container":"@set"
 	},
 	{
 		"uri":"http://purl.org/dc/terms/isPartOf",
 		"label":"Bestandteil von",
 		"name":"isPartOf",
-		"referenceType":"@id"
+		"referenceType":"@id",
+		"container":"@set"
 	},
 	{
 		"uri":"http://purl.org/dc/terms/issued",
 		"label":"Erschienen",
 		"name":"issued",
-		"referenceType":"String"
+		"referenceType":"String",
+		"container":"@set"
 	},
 	{
 		"uri":"http://purl.org/dc/terms/language",
 		"label":"Sprache",
 		"name":"language",
-		"referenceType":"@id"
+		"referenceType":"@id",
+		"container":"@set"
 	},
 	{
 		"uri":"http://purl.org/dc/terms/medium",
 		"label":"Träger",
 		"name":"medium",
-		"referenceType":"@id"
+		"referenceType":"@id",
+		"container":"@set"
 	},
 	{
 		"uri":"http://purl.org/dc/terms/modified",
 		"label":"Zuletzt bearbeitet",
 		"name":"dateModified",
-		"referenceType":"String"
+		"referenceType":"String",
+		"container":"@set"
 	},
 	{
 		"uri":"http://purl.org/dc/terms/source",
 		"label":"Quelle",
 		"name":"source",
-		"referenceType":"String"
+		"referenceType":"String",
+		"container":"@set"
 	},
 	{
 		"uri":"http://purl.org/dc/terms/spatial",
 		"label":"Ortsbezug",
 		"name":"spatial",
-		"referenceType":"@id"
+		"referenceType":"@id",
+		"container":"@set"
 	},
 	{
 		"uri":"http://purl.org/dc/terms/subject",
 		"label":"Schlagwort",
 		"icon":"fa fa-tag",
 		"name":"subject",
-		"referenceType":"@id"
+		"referenceType":"@id",
+		"container":"@set"
 	},
 	{
 		"uri":"http://purl.org/dc/terms/tableOfContents",
 		"label":"Inhaltsverzeichnis",
 		"icon":"fa fa-list",
 		"name":"tableOfContents",
-		"referenceType":"@id"
+		"referenceType":"@id",
+		"container":"@set"
 	},
 	{
 		"uri":"http://purl.org/dc/terms/title",
 		"label":"Titel",
 		"name":"title",
-		"referenceType":"String"
+		"referenceType":"String",
+		"container":"@set"
 	},
 	{
 		"uri":"http://purl.org/lobid/lv#containedIn",
 		"label":"Enthalten in",
 		"name":"containedIn",
-		"referenceType":"@id"
+		"referenceType":"@id",
+		"container":"@set"
 	},
 	{
 		"uri":"http://purl.org/lobid/lv#contributorLabel",
 		"label":"Mitwirkende",
 		"name":"contributorLabel",
-		"referenceType":"String"
-	},
-	{
-		"uri":"http://purl.org/ontology/bibo/contributorList",
-		"label":"contributorList",
-		"name":"contributorList",
-		"referenceType":"@list"
+		"referenceType":"String",
+		"container":"@set"
 	},
 	{
 		"uri":"http://purl.org/lobid/lv#fulltextOnline",
 		"label":"Online-Volltext",
 		"name":"fulltextOnline",
-		"referenceType":"@id"
+		"referenceType":"@id",
+		"container":"@set"
 	},
 	{
 		"uri":"http://purl.org/lobid/lv#hbzID",
 		"label":"Katalog Id",
 		"icon":"fa fa-bars",
 		"name":"hbzId",
-		"referenceType":"String"
+		"referenceType":"String",
+		"container":"@set"
 	},
 	{
 		"uri":"http://purl.org/lobid/lv#inSeries",
 		"label":"In Reihe",
 		"name":"inSeries",
-		"referenceType":"@id"
+		"referenceType":"@id",
+		"container":"@set"
 	},
 	{
 		"uri":"http://purl.org/lobid/lv#multiVolumeWork",
 		"label":"Mehrbändiges Werk",
 		"name":"multiVolumeWork",
-		"referenceType":"@id"
+		"referenceType":"@id",
+		"container":"@set"
 	},
 	{
 		"uri":"http://purl.org/lobid/lv#nameOfContributingCorporateBody",
 		"label":"Körperschaftsname",
 		"name":"contributingCorporateBodyLabel",
-		"referenceType":"String"
+		"referenceType":"String",
+		"container":"@set"
 	},
 	{
 		"uri":"http://purl.org/lobid/lv#numbering",
 		"label":"Nummer",
 		"name":"numbering",
-		"referenceType":"String"
+		"referenceType":"String",
+		"container":"@set"
 	},
 	{
 		"uri":"http://purl.org/lobid/lv#nwbibspatial",
 		"label":"Raumsystematik",
 		"name":"nwbibspatial",
-		"referenceType":"@id"
+		"referenceType":"@id",
+		"container":"@set"
 	},
 	{
 		"uri":"http://purl.org/lobid/lv#nwbibsubject",
 		"label":"Sachsystematik",
 		"name":"nwbibsubject",
-		"referenceType":"@id"
+		"referenceType":"@id",
+		"container":"@set"
 	},
 	{
 		"uri":"http://purl.org/lobid/lv#series",
 		"label":"Reihe",
 		"name":"series",
-		"referenceType":"@id"
+		"referenceType":"@id",
+		"container":"@set"
 	},
 	{
 		"uri":"http://purl.org/lobid/lv#subjectChain",
 		"label":"Schlagwortkette",
 		"name":"subjectChain",
-		"referenceType":"String"
+		"referenceType":"String",
+		"container":"@set"
 	},
 	{
 		"uri":"http://purl.org/lobid/lv#subjectLabel",
 		"label":"Schlagwort",
 		"name":"subjectLabel",
-		"referenceType":"String"
+		"referenceType":"String",
+		"container":"@set"
 	},
 	{
 		"uri":"http://purl.org/lobid/lv#subjectLocation",
 		"label":"Geokoordinaten",
 		"name":"subjectLocation",
-		"referenceType":"String"
+		"referenceType":"String",
+		"container":"@set"
 	},
 	{
 		"uri":"http://purl.org/lobid/lv#subjectOrder",
 		"label":"subjectOrdered",
 		"name":"subjectOrder",
-		"referenceType":"@list"
+		"referenceType":"String",
+		"container":"@list"
 	},
 	{
 		"uri":"http://purl.org/lobid/lv#titleKeyword",
 		"label":"Titelschlagwort",
 		"name":"titleKeyword",
-		"referenceType":"String"
+		"referenceType":"String",
+		"container":"@set"
 	},
 	{
 		"uri":"http://purl.org/lobid/lv#urn",
 		"label":"Urn",
 		"icon":"fa fa-exchange",
 		"name":"urn",
-		"referenceType":"String"
+		"referenceType":"String",
+		"container":"@set"
 	},
 	{
 		"uri":"http://purl.org/lobid/lv#volumeIn",
 		"label":"Gehört zu Band",
 		"name":"volumeIn",
-		"referenceType":"@id"
+		"referenceType":"@id",
+		"container":"@set"
 	},
 	{
 		"uri":"http://purl.org/lobid/lv#webPageArchived",
 		"label":"Archivierte Webseite",
 		"name":"webPageArchived",
-		"referenceType":"@id"
+		"referenceType":"@id",
+		"container":"@set"
 	},
 	{
 		"uri":"http://purl.org/lobid/lv#zdbID",
 		"label":"ZdbID",
 		"name":"zdbId",
-		"referenceType":"String"
+		"referenceType":"String",
+		"container":"@set"
 	},
 	{
 		"uri":"http://purl.org/lobid/rpb",
@@ -11548,244 +11626,291 @@
 		"referenceType":"http://www.w3.org/2004/02/skos/core#Concept"
 	},
 	{
+		"uri":"http://purl.org/ontology/bibo/contributorList",
+		"label":"contributorList",
+		"name":"contributorList",
+		"referenceType":"@id",
+		"container":"@list"
+	},
+	{
 		"uri":"http://purl.org/ontology/bibo/doi",
 		"label":"Doi",
 		"name":"doi",
-		"referenceType":"String"
+		"referenceType":"String",
+		"container":"@set"
 	},
 	{
 		"uri":"http://purl.org/ontology/bibo/edition",
 		"label":"Auflage",
 		"name":"edition",
-		"referenceType":"String"
+		"referenceType":"String",
+		"container":"@set"
 	},
 	{
 		"uri":"http://purl.org/ontology/bibo/editor",
 		"label":"Herausgeber/in",
 		"name":"editor",
-		"referenceType":"@id"
+		"referenceType":"@id",
+		"container":"@set"
 	},
 	{
 		"uri":"http://purl.org/ontology/bibo/eissn",
 		"label":"Eissn",
 		"name":"eissn",
-		"referenceType":"String"
+		"referenceType":"String",
+		"container":"@set"
 	},
 	{
 		"uri":"http://purl.org/ontology/bibo/isbn",
 		"label":"Isbn",
 		"name":"isbn",
-		"referenceType":"String"
+		"referenceType":"String",
+		"container":"@set"
 	},
 	{
 		"uri":"http://purl.org/ontology/bibo/issn",
 		"label":"Issn",
 		"name":"issn",
-		"referenceType":"String"
+		"referenceType":"String",
+		"container":"@set"
 	},
 	{
 		"uri":"http://purl.org/ontology/bibo/lccn",
 		"label":"Lccn",
 		"name":"lccn",
-		"referenceType":"String"
+		"referenceType":"String",
+		"container":"@set"
 	},
 	{
 		"uri":"http://purl.org/ontology/bibo/oclcnum",
 		"label":"Oclc",
 		"name":"oclcnum",
-		"referenceType":"String"
+		"referenceType":"String",
+		"container":"@set"
 	},
 	{
 		"uri":"http://purl.org/ontology/bibo/shortTitle",
 		"label":"Kurztitel",
 		"name":"shortTitle",
-		"referenceType":"String"
+		"referenceType":"String",
+		"container":"@set"
 	},
 	{
 		"uri":"http://purl.org/ontology/bibo/translator",
 		"label":"Übersetzung",
 		"name":"translator",
-		"referenceType":"@id"
+		"referenceType":"@id",
+		"container":"@set"
 	},
 	{
 		"uri":"http://purl.org/ontology/bibo/volume",
 		"label":"Band",
 		"name":"volume",
-		"referenceType":"@id"
+		"referenceType":"@id",
+		"container":"@set"
 	},
 	{
 		"uri":"http://purl.org/ontology/daia/label",
 		"label":"Signatur",
 		"name":"callNumber",
-		"referenceType":"String"
+		"referenceType":"String",
+		"container":"@set"
 	},
 	{
 		"uri":"http://purl.org/ontology/holding#collectedBy",
 		"label":"Gesammelt von",
 		"name":"collectedBy",
-		"referenceType":"@id"
+		"referenceType":"@id",
+		"container":"@set"
 	},
 	{
 		"uri":"http://purl.org/ontology/mo/ismn",
 		"label":"Ismn",
 		"name":"ismn",
-		"referenceType":"String"
+		"referenceType":"String",
+		"container":"@set"
 	},
 	{
 		"uri":"http://purl.org/ontology/mo/wikipedia",
 		"label":"Wikipedia",
 		"name":"wikipedia",
-		"referenceType":"@id"
+		"referenceType":"@id",
+		"container":"@set"
 	},
 	{
 		"uri":"http://purl.org/vocab/frbr/core#exemplar",
 		"label":"Exemplar",
 		"name":"exemplar",
-		"referenceType":"@id"
+		"referenceType":"@id",
+		"container":"@set"
 	},
 	{
 		"uri":"http://purl.org/vocab/frbr/core#exemplarOf",
 		"label":"Exemplar",
 		"name":"exemplarOf",
-		"referenceType":"@id"
+		"referenceType":"@id",
+		"container":"@set"
 	},
 	{
 		"uri":"http://purl.org/vocab/frbr/core#owner",
 		"label":"Besitz",
 		"name":"owner",
-		"referenceType":"@id"
+		"referenceType":"@id",
+		"container":"@set"
 	},
 	{
 		"uri":"http://rdaregistry.info/Elements/u/P60259",
 		"label":"Beilage zu",
 		"name":"isSupplementTo",
-		"referenceType":"String"
+		"referenceType":"String",
+		"container":"@set"
 	},
 	{
 		"uri":"http://rdaregistry.info/Elements/u/P60281",
 		"label":"Beilage",
 		"name":"hasSupplement",
-		"referenceType":"@id"
+		"referenceType":"@id",
+		"container":"@set"
 	},
 	{
 		"uri":"http://rdaregistry.info/Elements/u/P60489",
 		"label":"Hochschulschriftenvermerk",
 		"name":"thesisInformation",
-		"referenceType":"String"
+		"referenceType":"String",
+		"container":"@set"
 	},
 	{
 		"uri":"http://rdvocab.info/Elements/frequency",
 		"label":"Erscheinungsweise",
 		"name":"frequency",
-		"referenceType":"String"
+		"referenceType":"String",
+		"container":"@set"
 	},
 	{
 		"uri":"http://rdvocab.info/Elements/longitudeAndLatitude",
 		"label":"Geokoordinaten",
 		"name":"longitudeAndLatitude",
-		"referenceType":"String"
+		"referenceType":"String",
+		"container":"@set"
 	},
 	{
 		"uri":"http://rdvocab.info/Elements/otherTitleInformation",
 		"label":"Titelzusatz",
 		"name":"otherTitleInformation",
-		"referenceType":"String"
+		"referenceType":"String",
+		"container":"@set"
 	},
 	{
 		"uri":"http://rdvocab.info/Elements/placeOfPublication",
 		"label":"Ort der Herausgabe",
 		"icon":"fa fa-location-arrow",
 		"name":"placeOfPublication",
-		"referenceType":"String"
+		"referenceType":"String",
+		"container":"@set"
 	},
 	{
 		"uri":"http://rdvocab.info/Elements/publicationStatement",
 		"label":"Erscheinungsort und -jahr",
 		"name":"publicationStatement",
-		"referenceType":"String"
+		"referenceType":"String",
+		"container":"@set"
 	},
 	{
 		"uri":"http://rdvocab.info/Elements/statementOfResponsibility",
 		"label":"Verantwortlich",
 		"name":"statementOfResponsibility",
-		"referenceType":"String"
+		"referenceType":"String",
+		"container":"@set"
 	},
 	{
 		"uri":"http://rdvocab.info/RDARelationshipsWEMI/workManifested",
 		"label":"Werkebene",
 		"name":"workManifested",
-		"referenceType":"@id"
+		"referenceType":"@id",
+		"container":"@set"
 	},
 	{
 		"uri":"http://umbel.org/umbel#isLike",
 		"label":"Ähnlich zu",
 		"name":"similar",
-		"referenceType":"@id"
+		"referenceType":"@id",
+		"container":"@set"
 	},
 	{
 		"uri":"http://www.openarchives.org/ore/terms/isDescribedBy",
 		"label":"Beschrieben durch",
 		"name":"isDescribedBy",
-		"referenceType":"@id"
+		"referenceType":"@id",
+		"container":"@set"
 	},
 	{
 		"uri":"http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
 		"label":"Typ",
 		"name":"type",
-		"referenceType":"@id"
+		"referenceType":"@id",
+		"container":"@set"
 	},
 	{
 		"uri":"http://www.w3.org/2000/01/rdf-schema#inDataset",
 		"label":"Gehört zu Datenset",
 		"name":"inDataset",
-		"referenceType":"@id"
+		"referenceType":"@id",
+		"container":"@set"
 	},
 	{
 		"uri":"http://www.w3.org/2000/01/rdf-schema#seeAlso",
 		"label":"Weitere Informationen",
 		"name":"seeAlso",
-		"referenceType":"@id"
+		"referenceType":"@id",
+		"container":"@set"
 	},
 	{
 		"uri":"http://www.w3.org/2001/XMLSchema#",
 		"label":"XML Schema",
 		"name":"xsd",
-		"referenceType":"String"
+		"referenceType":"String",
+		"container":"@set"
 	},
 	{
 		"uri":"http://www.w3.org/2002/07/owl#sameAs",
 		"label":"Identisch zu",
 		"name":"sameAs",
-		"referenceType":"@id"
+		"referenceType":"@id",
+		"container":"@set"
 	},
 	{
 		"uri":"http://www.w3.org/2004/02/skos/core#note",
 		"label":"Hinweis",
 		"name":"note",
-		"referenceType":"String"
+		"referenceType":"String",
+		"container":"@set"
 	},
 	{
 		"uri":"http://www.w3.org/2004/02/skos/core#prefLabel",
 		"label":"Etikett",
 		"name":"prefLabel",
-		"referenceType":"String"
+		"referenceType":"String",
+		"container":"@set"
 	},
 	{
 		"uri":"http://www.w3.org/2007/05/powder-s#describedby",
 		"label":"Beschrieben durch",
 		"name":"describedby",
-		"referenceType":"@id"
+		"referenceType":"@id",
+		"container":"@set"
 	},
 	{
 		"uri":"http://xmlns.com/foaf/0.1/isPrimaryTopicOf",
 		"label":"Weitere Informationen",
 		"name":"isPrimaryTopicOf",
-		"referenceType":"@id"
+		"referenceType":"@id",
+		"container":"@set"
 	},
 	{
 		"uri":"http://xmlns.com/foaf/0.1/primaryTopic",
 		"label":"Beschreibt",
 		"name":"primaryTopic",
-		"referenceType":"@id"
+		"referenceType":"@id",
+		"container":"@set"
 	}
 ]


### PR DESCRIPTION
Support the extended etikett format with an additional container attribute. The new container attribute can be used to express sets and lists in a manner that can be understood by rdf converters to produce rdf lists from json-ld. 
