### PR TITLE
Move "@type" and "@id" to context

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>de.hbz.lobid</groupId>
   <artifactId>lobid-rdf-to-json</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
+  <version>0.0.2-SNAPSHOT</version>
   <properties>
     <logback.version>0.9.30</logback.version>
     <slf4j.version>1.6.2</slf4j.version>

--- a/src/main/java/de/hbz/lobid/helper/JsonConverter.java
+++ b/src/main/java/de/hbz/lobid/helper/JsonConverter.java
@@ -50,6 +50,8 @@ public class JsonConverter {
 	String first = "http://www.w3.org/1999/02/22-rdf-syntax-ns#first";
 	String rest = "http://www.w3.org/1999/02/22-rdf-syntax-ns#rest";
 	String nil = "http://www.w3.org/1999/02/22-rdf-syntax-ns#nil";
+	private static final String RDF_TYPE =
+			"http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
 
 	private static ObjectMapper objectMapper = new ObjectMapper();
 	Set<Statement> all = new HashSet<>();
@@ -84,7 +86,7 @@ public class JsonConverter {
 	private Map<String, Object> createMap(Graph g) {
 		Map<String, Object> jsonResult = new TreeMap<>();
 		Iterator<Statement> i = g.iterator();
-		jsonResult.put("@id", mainSubjectOfTheResource);
+		jsonResult.put("id", mainSubjectOfTheResource);
 		while (i.hasNext()) {
 			Statement s = i.next();
 			if (mainSubjectOfTheResource.equals(s.getSubject().stringValue())) {
@@ -98,7 +100,8 @@ public class JsonConverter {
 	private void createObject(Map<String, Object> jsonResult, Statement s,
 			Etikett e) {
 		String key = e.name;
-		if (s.getObject() instanceof org.openrdf.model.Literal) {
+		if (s.getObject() instanceof org.openrdf.model.Literal
+				|| s.getPredicate().stringValue().equals(RDF_TYPE)) {
 			addLiteralToJsonResult(jsonResult, key, s.getObject().stringValue());
 		} else {
 			if (s.getObject() instanceof org.openrdf.model.BNode) {
@@ -186,7 +189,7 @@ public class JsonConverter {
 	private Map<String, Object> createObjectWithId(String uri) {
 		Map<String, Object> newObject = new TreeMap<>();
 		if (uri != null) {
-			newObject.put("@id", uri);
+			newObject.put("id", uri);
 			createObject(uri, newObject);
 		}
 		return newObject;

--- a/src/main/resources/context.json
+++ b/src/main/resources/context.json
@@ -1,5 +1,7 @@
 {
 	"@context":{
+		"id": "@id",
+		"type": "@type",
 		"extent":{
 			"@id":"http://iflastandards.info/ns/isbd/elements/P1053",
 			"label":"Umfang",
@@ -15,12 +17,6 @@
 			"@type":"@id",
 			"@id":"http://id.loc.gov/vocabulary/relators/ant",
 			"label":"Basiert auf das Werk von",
-			"@container":"@set"
-		},
-		"type":{
-			"@type":"@id",
-			"@id":"http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
-			"label":"Typ",
 			"@container":"@set"
 		},
 		"preferredNameForThePlaceOrGeographicName":{

--- a/src/test/resources/hbz01.es.json
+++ b/src/test/resources/hbz01.es.json
@@ -1,53 +1,49 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/HT018454638",
   "contributor" : [ {
-    "@id" : "http://d-nb.info/gnd/2175350-7",
+    "id" : "http://d-nb.info/gnd/2175350-7",
     "preferredName" : "Pfarrei Sankt Antonius Abbas Herkenrath",
     "preferredNameForTheCorporateBody" : "Pfarrei Sankt Antonius Abbas Herkenrath",
     "preferredNameForThePerson" : "Pfarrei Sankt Antonius Abbas Herkenrath"
   }, {
-    "@id" : "http://d-nb.info/gnd/1060772442",
+    "id" : "http://d-nb.info/gnd/1060772442",
     "preferredName" : "Pfarrei St. Joseph und St. Antonius Bergisch Gladbach",
     "preferredNameForTheCorporateBody" : "Pfarrei St. Joseph und St. Antonius Bergisch Gladbach",
     "preferredNameForThePerson" : "Pfarrei St. Joseph und St. Antonius Bergisch Gladbach"
   }, {
-    "@id" : "http://d-nb.info/gnd/172845785",
+    "id" : "http://d-nb.info/gnd/172845785",
     "preferredName" : "Clemens-Schierbaum, Ursula, 1963-",
     "preferredNameForThePerson" : "Clemens-Schierbaum, Ursula, 1963-"
   } ],
   "contributorOrder" : [ "http://d-nb.info/gnd/172845785 | http://d-nb.info/gnd/1060772442 | http://d-nb.info/gnd/2175350-7" ],
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/HT018454638/about",
     "dateCreated" : "20141111",
-    "dateModified" : "20150303"
+    "dateModified" : "20150303",
+    "id" : "http://lobid.org/resource/HT018454638/about"
   } ],
   "exemplar" : [ {
-    "@id" : "http://lobid.org/item/HT018454638:DE-5-39:Gb%207470%2F201"
+    "id" : "http://lobid.org/item/HT018454638:DE-5-39:Gb%207470%2F201"
   }, {
-    "@id" : "http://lobid.org/item/HT018454638:DE-Kn28:Fc%206601"
+    "id" : "http://lobid.org/item/HT018454638:DE-Kn28:Fc%206601"
   } ],
+  "id" : "http://lobid.org/resource/HT018454638",
   "language" : [ {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
   } ],
   "medium" : [ {
-    "@id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
+    "id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
   } ],
   "subject" : [ {
-    "@id" : "http://d-nb.info/gnd/2175350-7",
+    "id" : "http://d-nb.info/gnd/2175350-7",
     "preferredName" : "Pfarrei Sankt Antonius Abbas Herkenrath",
     "preferredNameForTheCorporateBody" : "Pfarrei Sankt Antonius Abbas Herkenrath",
     "preferredNameForThePerson" : "Pfarrei Sankt Antonius Abbas Herkenrath"
   }, {
-    "@id" : "http://d-nb.info/gnd/1060772442",
+    "id" : "http://d-nb.info/gnd/1060772442",
     "preferredName" : "Pfarrei St. Joseph und St. Antonius Bergisch Gladbach",
     "preferredNameForTheCorporateBody" : "Pfarrei St. Joseph und St. Antonius Bergisch Gladbach",
     "preferredNameForThePerson" : "Pfarrei St. Joseph und St. Antonius Bergisch Gladbach"
   } ],
   "subjectOrder" : [ "http://d-nb.info/gnd/1060772442", "http://d-nb.info/gnd/2175350-7", "Geschichte" ],
-  "type" : [ {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  }, {
-    "@id" : "http://purl.org/ontology/bibo/Book"
-  } ]
+  "type" : [ "http://purl.org/ontology/bibo/Book", "http://purl.org/dc/terms/BibliographicResource" ]
 }

--- a/src/test/resources/hbz01.es.wrongContributorOrder.json
+++ b/src/test/resources/hbz01.es.wrongContributorOrder.json
@@ -1,53 +1,49 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/HT018454638",
   "contributor" : [ {
-    "@id" : "http://d-nb.info/gnd/2175350-7",
+    "id" : "http://d-nb.info/gnd/2175350-7",
     "preferredName" : "Pfarrei Sankt Antonius Abbas Herkenrath",
     "preferredNameForTheCorporateBody" : "Pfarrei Sankt Antonius Abbas Herkenrath",
     "preferredNameForThePerson" : "Pfarrei Sankt Antonius Abbas Herkenrath"
   }, {
-    "@id" : "http://d-nb.info/gnd/1060772442",
+    "id" : "http://d-nb.info/gnd/1060772442",
     "preferredName" : "Pfarrei St. Joseph und St. Antonius Bergisch Gladbach",
     "preferredNameForTheCorporateBody" : "Pfarrei St. Joseph und St. Antonius Bergisch Gladbach",
     "preferredNameForThePerson" : "Pfarrei St. Joseph und St. Antonius Bergisch Gladbach"
   }, {
-    "@id" : "http://d-nb.info/gnd/172845785",
+    "id" : "http://d-nb.info/gnd/172845785",
     "preferredName" : "Clemens-Schierbaum, Ursula, 1963-",
     "preferredNameForThePerson" : "Clemens-Schierbaum, Ursula, 1963-"
   } ],
-  "contributorOrder" : [ "http://d-nb.info/gnd/1060772442 | http://d-nb.info/gnd/2175350-7 | http://d-nb.info/gnd/172845785" ],
+  "contributorOrder" : [ "http://d-nb.info/gnd/51060772442 | http://d-nb.info/gnd/17284578 | http://d-nb.info/gnd/2175350-7" ],
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/HT018454638/about",
     "dateCreated" : "20141111",
-    "dateModified" : "20150303"
+    "dateModified" : "20150303",
+    "id" : "http://lobid.org/resource/HT018454638/about"
   } ],
   "exemplar" : [ {
-    "@id" : "http://lobid.org/item/HT018454638:DE-5-39:Gb%207470%2F201"
+    "id" : "http://lobid.org/item/HT018454638:DE-5-39:Gb%207470%2F201"
   }, {
-    "@id" : "http://lobid.org/item/HT018454638:DE-Kn28:Fc%206601"
+    "id" : "http://lobid.org/item/HT018454638:DE-Kn28:Fc%206601"
   } ],
+  "id" : "http://lobid.org/resource/HT018454638",
   "language" : [ {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
   } ],
   "medium" : [ {
-    "@id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
+    "id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
   } ],
   "subject" : [ {
-    "@id" : "http://d-nb.info/gnd/2175350-7",
+    "id" : "http://d-nb.info/gnd/2175350-7",
     "preferredName" : "Pfarrei Sankt Antonius Abbas Herkenrath",
     "preferredNameForTheCorporateBody" : "Pfarrei Sankt Antonius Abbas Herkenrath",
     "preferredNameForThePerson" : "Pfarrei Sankt Antonius Abbas Herkenrath"
   }, {
-    "@id" : "http://d-nb.info/gnd/1060772442",
+    "id" : "http://d-nb.info/gnd/1060772442",
     "preferredName" : "Pfarrei St. Joseph und St. Antonius Bergisch Gladbach",
     "preferredNameForTheCorporateBody" : "Pfarrei St. Joseph und St. Antonius Bergisch Gladbach",
     "preferredNameForThePerson" : "Pfarrei St. Joseph und St. Antonius Bergisch Gladbach"
   } ],
   "subjectOrder" : [ "http://d-nb.info/gnd/1060772442", "http://d-nb.info/gnd/2175350-7", "Geschichte" ],
-  "type" : [ {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  }, {
-    "@id" : "http://purl.org/ontology/bibo/Book"
-  } ]
+  "type" : [ "http://purl.org/ontology/bibo/Book", "http://purl.org/dc/terms/BibliographicResource" ]
 }

--- a/src/test/resources/output/json/00000/BT000002852.json
+++ b/src/test/resources/output/json/00000/BT000002852.json
@@ -1,46 +1,46 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/BT000002852",
   "collectedBy" : [ {
-    "@id" : "http://lobid.org/resource/NWBib"
+    "id" : "http://lobid.org/resource/NWBib"
   } ],
   "contributorOrder" : [ "http://d-nb.info/gnd/4018466-3" ],
   "coverage" : [ "Freudenberg <Siegen-Wittgenstein>" ],
   "creator" : [ {
-    "@id" : "http://d-nb.info/gnd/4018466-3",
+    "id" : "http://d-nb.info/gnd/4018466-3",
     "preferredName" : "Freudenberg, Kreis Siegen-Wittgenstein",
     "preferredNameForThePlaceOrGeographicName" : "Freudenberg"
   } ],
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/BT000002852/about",
     "dateCreated" : "19960513",
-    "dateModified" : "19960513"
+    "dateModified" : "19960513",
+    "id" : "http://lobid.org/resource/BT000002852/about"
   } ],
   "extent" : [ "46 S. : Ill., Kt." ],
   "hbzId" : [ "BT000002852" ],
+  "id" : "http://lobid.org/resource/BT000002852",
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DBT000002852"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DBT000002852"
   } ],
   "issued" : [ "1989" ],
   "medium" : [ {
-    "@id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
+    "id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
   } ],
   "nwbibsubject" : [ {
-    "@id" : "http://purl.org/lobid/nwbib#s240000"
+    "id" : "http://purl.org/lobid/nwbib#s240000"
   } ],
   "otherTitleInformation" : [ "wechselvolle Geschichte" ],
   "placeOfPublication" : [ "Freudenberg" ],
   "publicationStatement" : [ "Freudenberg; 1989" ],
   "sameAs" : [ {
-    "@id" : "http://hub.culturegraph.org/resource/HBZ-BT000002852"
+    "id" : "http://hub.culturegraph.org/resource/HBZ-BT000002852"
   } ],
   "statementOfResponsibility" : [ "[Hrsg.: Stadt Freudenberg, Der Stadtdirektor]" ],
   "subject" : [ {
-    "@id" : "http://d-nb.info/gnd/4020517-4",
+    "id" : "http://d-nb.info/gnd/4020517-4",
     "preferredName" : "Geschichte",
     "preferredNameForTheSubjectHeading" : "Geschichte"
   }, {
-    "@id" : "http://d-nb.info/gnd/4018466-3",
+    "id" : "http://d-nb.info/gnd/4018466-3",
     "preferredName" : "Freudenberg, Kreis Siegen-Wittgenstein",
     "preferredNameForThePlaceOrGeographicName" : "Freudenberg"
   } ],
@@ -48,9 +48,5 @@
   "subjectLabel" : [ "Freudenberg Siegen", "Landesgeschichte", "Freudenberg (Siegerland)", "Ortsgeschichte", "Stadt Freudenberg", "Zeitgeschichte", "Stadt Freudenberg Südwestfalen", "Regionalgeschichte" ],
   "subjectOrder" : [ "http://d-nb.info/gnd/4018466-3, http://d-nb.info/gnd/4020517-4" ],
   "title" : [ "Stadt Freudenberg" ],
-  "type" : [ {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  }, {
-    "@id" : "http://purl.org/ontology/bibo/Book"
-  } ]
+  "type" : [ "http://purl.org/ontology/bibo/Book", "http://purl.org/dc/terms/BibliographicResource" ]
 }

--- a/src/test/resources/output/json/00000/BT000003404.json
+++ b/src/test/resources/output/json/00000/BT000003404.json
@@ -1,52 +1,52 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/BT000003404",
   "collectedBy" : [ {
-    "@id" : "http://lobid.org/resource/NWBib"
+    "id" : "http://lobid.org/resource/NWBib"
   } ],
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/BT000003404/about",
     "dateCreated" : "19940829",
-    "dateModified" : "20101004"
+    "dateModified" : "20101004",
+    "id" : "http://lobid.org/resource/BT000003404/about"
   } ],
   "edition" : [ "10.[Aufl., Ausg.] 1993/94" ],
   "extent" : [ "Kt." ],
   "hbzId" : [ "BT000003404" ],
+  "id" : "http://lobid.org/resource/BT000003404",
   "isPartOf" : [ {
-    "@id" : "http://lobid.org/resource/BT000100437"
+    "id" : "http://lobid.org/resource/BT000100437"
   } ],
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DBT000003404"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DBT000003404"
   } ],
   "isbn" : [ "3575112088", "9783575112088" ],
   "issued" : [ "1993" ],
   "language" : [ {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
   } ],
   "medium" : [ {
-    "@id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
+    "id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
   }, {
-    "@id" : "http://purl.org/ontology/bibo/Map"
+    "id" : "http://purl.org/ontology/bibo/Map"
   } ],
   "nwbibspatial" : [ {
-    "@id" : "http://purl.org/lobid/nwbib-spatial#n01"
+    "id" : "http://purl.org/lobid/nwbib-spatial#n01"
   } ],
   "nwbibsubject" : [ {
-    "@id" : "http://purl.org/lobid/nwbib#s126000"
+    "id" : "http://purl.org/lobid/nwbib#s126000"
   } ],
   "otherTitleInformation" : [ "mit Ortsverzeichnis" ],
   "placeOfPublication" : [ "Berlin [u.a.]" ],
   "publicationStatement" : [ "Berlin [u.a.]; Berlin [u.a.]; Reise- u. Verkehrsverl.; Reise- u. Verkehrsverl.; 1993" ],
   "publisher" : [ "Reise- u. Verkehrsverl." ],
   "sameAs" : [ {
-    "@id" : "http://hub.culturegraph.org/resource/HBZ-BT000003404"
+    "id" : "http://hub.culturegraph.org/resource/HBZ-BT000003404"
   } ],
   "subject" : [ {
-    "@id" : "http://d-nb.info/gnd/4115393-5",
+    "id" : "http://d-nb.info/gnd/4115393-5",
     "preferredName" : "Niedersachsen, Süd",
     "preferredNameForThePlaceOrGeographicName" : "Niedersachsen"
   }, {
-    "@id" : "http://d-nb.info/gnd/4042570-8",
+    "id" : "http://d-nb.info/gnd/4042570-8",
     "preferredName" : "Nordrhein-Westfalen",
     "preferredNameForThePlaceOrGeographicName" : "Nordrhein-Westfalen"
   } ],
@@ -54,19 +54,13 @@
   "subjectLabel" : [ "NRW", "Nord-Westphalie", "Noordrijn-Westfalen", "NW", "Südliches Niedersachsen", "Südniedersachsen", "Norte-Westfalia", "North Rhine-Westphalia" ],
   "subjectOrder" : [ "http://d-nb.info/gnd/4042570-8, Karte", "http://d-nb.info/gnd/4115393-5, Karte" ],
   "title" : [ "Deutschland 1:300000", "Deutschland, 2: Nordrhein-Westfalen, Niedersachsen-Süd" ],
-  "type" : [ {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  }, {
-    "@id" : "http://purl.org/ontology/bibo/Article"
-  } ],
+  "type" : [ "http://purl.org/ontology/bibo/Article", "http://purl.org/dc/terms/BibliographicResource" ],
   "volume" : [ "2" ],
   "volumeIn" : [ {
     "multiVolumeWork" : [ {
-      "@id" : "http://lobid.org/resource/BT000100437"
+      "id" : "http://lobid.org/resource/BT000100437"
     } ],
     "numbering" : "2",
-    "type" : [ {
-      "@id" : "http://purl.org/lobid/lv#MultiVolumeWorkRelation"
-    } ]
+    "type" : [ "http://purl.org/lobid/lv#MultiVolumeWorkRelation" ]
   } ]
 }

--- a/src/test/resources/output/json/00000/HT000009600.json
+++ b/src/test/resources/output/json/00000/HT000009600.json
@@ -1,564 +1,484 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/HT000009600",
   "contributingCorporateBodyLabel" : [ "Angestellten-Gewerkschaft", "DAG", "Deutsche Angestellten-Gewerkschaft", "Gewerkschaft der Deutschen Angestellten" ],
   "contributor" : [ {
-    "@id" : "http://d-nb.info/gnd/37043-5",
+    "id" : "http://d-nb.info/gnd/37043-5",
     "preferredName" : "Deutsche Angestellten-Gewerkschaft",
     "preferredNameForTheCorporateBody" : "Deutsche Angestellten-Gewerkschaft"
   } ],
   "contributorOrder" : [ "http://d-nb.info/gnd/37043-5" ],
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/HT000009600/about",
     "dateCreated" : "19991118",
-    "dateModified" : "20120319"
+    "dateModified" : "20120319",
+    "id" : "http://lobid.org/resource/HT000009600/about"
   } ],
   "exemplar" : [ {
-    "@id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%204.1951",
-    "callNumber" : "Bg 168: 4.1951",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%204.1951/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT000009600",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Bm3-3"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1973",
-    "callNumber" : "Bg 168:1973",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1973/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT000009600",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Bm3-3"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%208.1955",
-    "callNumber" : "Bg 168: 8.1955",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%208.1955/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT000009600",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Bm3-3"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:23-24.1970-71",
-    "callNumber" : "Bg 168:23-24.1970-71",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:23-24.1970-71/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT000009600",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Bm3-3"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1977",
-    "callNumber" : "Bg 168:1977",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1977/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT000009600",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Bm3-3"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT000009600:DE-Bo133:Z%20848",
-    "callNumber" : "Z 848",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT000009600:DE-Bo133:Z%20848/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT000009600",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Bo133"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1965",
-    "callNumber" : "Bg 168:1965",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1965/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT000009600",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Bm3-3"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%201-2.1948-49",
-    "callNumber" : "Bg 168: 1-2.1948-49",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%201-2.1948-49/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT000009600",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Bm3-3"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1982",
-    "callNumber" : "Bg 168:1982",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1982/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT000009600",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Bm3-3"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT000009600:DE-294-17:BX-7",
-    "callNumber" : "BX-7",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT000009600:DE-294-17:BX-7/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT000009600",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-294-17"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1968",
-    "callNumber" : "Bg 168:1968",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1968/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT000009600",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Bm3-3"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1983",
-    "callNumber" : "Bg 168:1983",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1983/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT000009600",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Bm3-3"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1966",
-    "callNumber" : "Bg 168:1966",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1966/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT000009600",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Bm3-3"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT000009600:DE-Bo133:AMZ%20336",
-    "callNumber" : "AMZ 336",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT000009600:DE-Bo133:AMZ%20336/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT000009600",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Bo133"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1967",
-    "callNumber" : "Bg 168:1967",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1967/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT000009600",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Bm3-3"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT000009600:DE-60:Zs%201545",
-    "callNumber" : "Zs 1545",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT000009600:DE-60:Zs%201545/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT000009600",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-60"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%207.1954",
-    "callNumber" : "Bg 168: 7.1954",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%207.1954/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT000009600",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Bm3-3"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1980",
-    "callNumber" : "Bg 168:1980",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1980/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT000009600",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Bm3-3"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT000009600:DE-Bo102:Zs%20371",
     "callNumber" : "Zs 371",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT000009600:DE-Bo102:Zs%20371/about"
+      "id" : "http://lobid.org/item/HT000009600:DE-Bo102:Zs%20371/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT000009600",
+    "id" : "http://lobid.org/item/HT000009600:DE-Bo102:Zs%20371",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Bo102"
+      "id" : "http://lobid.org/organisation/DE-Bo102"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT000009600:DE-464:D%2000%2F49%20Z%2025",
-    "callNumber" : "D 00/49 Z 25",
+    "callNumber" : "Bg 168: 1-2.1948-49",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT000009600:DE-464:D%2000%2F49%20Z%2025/about"
+      "id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%201-2.1948-49/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT000009600",
+    "id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%201-2.1948-49",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-464"
+      "id" : "http://lobid.org/organisation/DE-Bm3-3"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:11-13.1958-60",
-    "callNumber" : "Bg 168:11-13.1958-60",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:11-13.1958-60/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT000009600",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Bm3-3"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT000009600:DE-Bm3:Bg%20168",
-    "callNumber" : "Bg 168",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT000009600:DE-Bm3:Bg%20168/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT000009600",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Bm3"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1978",
-    "callNumber" : "Bg 168:1978",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1978/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT000009600",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Bm3-3"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1964",
-    "callNumber" : "Bg 168:1964",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1964/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT000009600",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Bm3-3"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1976",
-    "callNumber" : "Bg 168:1976",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1976/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT000009600",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Bm3-3"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1981",
     "callNumber" : "Bg 168:1981",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1981/about"
+      "id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1981/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT000009600",
+    "id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1981",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Bm3-3"
+      "id" : "http://lobid.org/organisation/DE-Bm3-3"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1963",
-    "callNumber" : "Bg 168:1963",
+    "callNumber" : "Bg 168:1965",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1963/about"
+      "id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1965/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT000009600",
+    "id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1965",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Bm3-3"
+      "id" : "http://lobid.org/organisation/DE-Bm3-3"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:14-15.1961-62",
-    "callNumber" : "Bg 168:14-15.1961-62",
+    "callNumber" : "Bg 168:1968",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:14-15.1961-62/about"
+      "id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1968/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT000009600",
+    "id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1968",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Bm3-3"
+      "id" : "http://lobid.org/organisation/DE-Bm3-3"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1974",
-    "callNumber" : "Bg 168:1974",
+    "callNumber" : "Bg 168: 4.1951",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1974/about"
+      "id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%204.1951/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT000009600",
+    "id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%204.1951",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Bm3-3"
+      "id" : "http://lobid.org/organisation/DE-Bm3-3"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%205-6.11952-53",
-    "callNumber" : "Bg 168: 5-6.11952-53",
+    "callNumber" : "Bg 168:1983",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%205-6.11952-53/about"
+      "id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1983/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT000009600",
+    "id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1983",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Bm3-3"
+      "id" : "http://lobid.org/organisation/DE-Bm3-3"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT000009600:DE-38:Haa1455",
-    "callNumber" : "Haa1455",
+    "callNumber" : "Bg 168: 8.1955",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT000009600:DE-38:Haa1455/about"
+      "id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%208.1955/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT000009600",
+    "id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%208.1955",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-38"
+      "id" : "http://lobid.org/organisation/DE-Bm3-3"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT000009600:DE-260:Z%201009",
-    "callNumber" : "Z 1009",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT000009600:DE-260:Z%201009/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT000009600",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-260"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:10.1957",
-    "callNumber" : "Bg 168:10.1957",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:10.1957/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT000009600",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Bm3-3"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1975",
     "callNumber" : "Bg 168:1975",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1975/about"
+      "id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1975/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT000009600",
+    "id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1975",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Bm3-3"
+      "id" : "http://lobid.org/organisation/DE-Bm3-3"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%209.1956",
-    "callNumber" : "Bg 168: 9.1956",
+    "callNumber" : "Bg 168:1977",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%209.1956/about"
+      "id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1977/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT000009600",
+    "id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1977",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Bm3-3"
+      "id" : "http://lobid.org/organisation/DE-Bm3-3"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1969",
+    "callNumber" : "Z 848",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT000009600:DE-Bo133:Z%20848/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT000009600",
+    "id" : "http://lobid.org/item/HT000009600:DE-Bo133:Z%20848",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-Bo133"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "Bg 168:1978",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1978/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT000009600",
+    "id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1978",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-Bm3-3"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "Bg 168:1963",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1963/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT000009600",
+    "id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1963",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-Bm3-3"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "Bg 168:1966",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1966/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT000009600",
+    "id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1966",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-Bm3-3"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "AMZ 336",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT000009600:DE-Bo133:AMZ%20336/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT000009600",
+    "id" : "http://lobid.org/item/HT000009600:DE-Bo133:AMZ%20336",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-Bo133"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "Bg 168:1967",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1967/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT000009600",
+    "id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1967",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-Bm3-3"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "Bg 168:23-24.1970-71",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:23-24.1970-71/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT000009600",
+    "id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:23-24.1970-71",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-Bm3-3"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "Bg 168:1973",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1973/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT000009600",
+    "id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1973",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-Bm3-3"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "Bg 168:1976",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1976/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT000009600",
+    "id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1976",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-Bm3-3"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "Zs 1545",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT000009600:DE-60:Zs%201545/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT000009600",
+    "id" : "http://lobid.org/item/HT000009600:DE-60:Zs%201545",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-60"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "Bg 168: 7.1954",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%207.1954/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT000009600",
+    "id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%207.1954",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-Bm3-3"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "D 00/49 Z 25",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT000009600:DE-464:D%2000%2F49%20Z%2025/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT000009600",
+    "id" : "http://lobid.org/item/HT000009600:DE-464:D%2000%2F49%20Z%2025",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-464"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "Bg 168",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT000009600:DE-Bm3:Bg%20168/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT000009600",
+    "id" : "http://lobid.org/item/HT000009600:DE-Bm3:Bg%20168",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-Bm3"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "Bg 168:11-13.1958-60",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:11-13.1958-60/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT000009600",
+    "id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:11-13.1958-60",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-Bm3-3"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "Bg 168:1964",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1964/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT000009600",
+    "id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1964",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-Bm3-3"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "Haa1455",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT000009600:DE-38:Haa1455/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT000009600",
+    "id" : "http://lobid.org/item/HT000009600:DE-38:Haa1455",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-38"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "Bg 168: 5-6.11952-53",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%205-6.11952-53/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT000009600",
+    "id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%205-6.11952-53",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-Bm3-3"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "Bg 168:1974",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1974/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT000009600",
+    "id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1974",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-Bm3-3"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "Bg 168:1980",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1980/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT000009600",
+    "id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1980",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-Bm3-3"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "Bg 168:1982",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1982/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT000009600",
+    "id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1982",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-Bm3-3"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
     "callNumber" : "Bg 168:1969",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1969/about"
+      "id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1969/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT000009600",
+    "id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1969",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Bm3-3"
+      "id" : "http://lobid.org/organisation/DE-Bm3-3"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1978.86%20Register%20%5BL%5D",
-    "callNumber" : "Bg 168:1978.86 Register [L]",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1978.86%20Register%20%5BL%5D/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT000009600",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Bm3-3"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1972",
     "callNumber" : "Bg 168:1972",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1972/about"
+      "id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1972/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT000009600",
+    "id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1972",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Bm3-3"
+      "id" : "http://lobid.org/organisation/DE-Bm3-3"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1979",
-    "callNumber" : "Bg 168:1979",
+    "callNumber" : "BX-7",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1979/about"
+      "id" : "http://lobid.org/item/HT000009600:DE-294-17:BX-7/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT000009600",
+    "id" : "http://lobid.org/item/HT000009600:DE-294-17:BX-7",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Bm3-3"
+      "id" : "http://lobid.org/organisation/DE-294-17"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%203.1950",
     "callNumber" : "Bg 168: 3.1950",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%203.1950/about"
+      "id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%203.1950/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT000009600",
+    "id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%203.1950",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Bm3-3"
+      "id" : "http://lobid.org/organisation/DE-Bm3-3"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "Bg 168:14-15.1961-62",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:14-15.1961-62/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT000009600",
+    "id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:14-15.1961-62",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-Bm3-3"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "Bg 168:10.1957",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:10.1957/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT000009600",
+    "id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:10.1957",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-Bm3-3"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "Z 1009",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT000009600:DE-260:Z%201009/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT000009600",
+    "id" : "http://lobid.org/item/HT000009600:DE-260:Z%201009",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-260"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "Bg 168: 9.1956",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%209.1956/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT000009600",
+    "id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:%209.1956",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-Bm3-3"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "Bg 168:1978.86 Register [L]",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1978.86%20Register%20%5BL%5D/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT000009600",
+    "id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1978.86%20Register%20%5BL%5D",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-Bm3-3"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "Bg 168:1979",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1979/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT000009600",
+    "id" : "http://lobid.org/item/HT000009600:DE-Bm3-3:Bg%20168:1979",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-Bm3-3"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   } ],
   "frequency" : [ "Bei Jg. 28 setzt die durchgehende Nr.-Zählung ein" ],
   "hasSupplement" : [ {
-    "@id" : "http://lobid.org/resource/HT006886477"
+    "id" : "http://lobid.org/resource/HT006886477"
   }, {
-    "@id" : "http://lobid.org/resource/HT006886478"
+    "id" : "http://lobid.org/resource/HT006886478"
   }, {
-    "@id" : "http://lobid.org/resource/HT012299746"
+    "id" : "http://lobid.org/resource/HT012299746"
   }, {
-    "@id" : "http://lobid.org/resource/HT006886479"
+    "id" : "http://lobid.org/resource/HT006886479"
   }, {
-    "@id" : "http://lobid.org/resource/HT007527436"
+    "id" : "http://lobid.org/resource/HT007527436"
   }, {
-    "@id" : "http://lobid.org/resource/HT006886476"
+    "id" : "http://lobid.org/resource/HT006886476"
   } ],
   "hbzId" : [ "HT000009600" ],
+  "id" : "http://lobid.org/resource/HT000009600",
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT000009600"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT000009600"
   } ],
   "issn" : [ "0028307x" ],
   "issued" : [ "1948 - 1983" ],
   "language" : [ {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
   } ],
   "medium" : [ {
-    "@id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
+    "id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
   } ],
   "oclcnum" : [ "263589870" ],
   "otherTitleInformation" : [ "Zeitschrift der Deutschen Angestellten-Gewerkschaft", "Der Angestellte" ],
@@ -566,26 +486,22 @@
   "publicationStatement" : [ "Hamburg; DAG; 1948" ],
   "publisher" : [ "DAG" ],
   "sameAs" : [ {
-    "@id" : "http://lobid.org/resource/ZDB6211-x",
     "describedby" : [ {
-      "@id" : "http://lobid.org/resource/ZDB6211-x/about"
+      "id" : "http://lobid.org/resource/ZDB6211-x/about"
     } ],
+    "id" : "http://lobid.org/resource/ZDB6211-x",
     "sameAs" : "http://lobid.org/resource/HT000009600"
   }, {
-    "@id" : "http://worldcat.org/oclc/263589870"
+    "id" : "http://worldcat.org/oclc/263589870"
   }, {
-    "@id" : "http://ld.zdb-services.de/resource/6211-x"
+    "id" : "http://ld.zdb-services.de/resource/6211-x"
   } ],
   "subject" : [ {
-    "@id" : "http://dewey.info/class/330/"
+    "id" : "http://dewey.info/class/330/"
   }, {
-    "@id" : "http://dewey.info/class/360/"
+    "id" : "http://dewey.info/class/360/"
   } ],
   "title" : [ "Der Angestellte Hamburg" ],
-  "type" : [ {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  }, {
-    "@id" : "http://purl.org/ontology/bibo/Journal"
-  } ],
+  "type" : [ "http://purl.org/ontology/bibo/Journal", "http://purl.org/dc/terms/BibliographicResource" ],
   "zdbId" : [ "6211-x" ]
 }

--- a/src/test/resources/output/json/00004/BT000040377.json
+++ b/src/test/resources/output/json/00004/BT000040377.json
@@ -1,50 +1,46 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/BT000040377",
   "bibliographicCitation" : [ "Rheine gestern, heute, morgen. - 11 (1983), S. 26-38 : Abb." ],
   "collectedBy" : [ {
-    "@id" : "http://lobid.org/resource/NWBib"
+    "id" : "http://lobid.org/resource/NWBib"
   } ],
   "containedIn" : [ {
-    "@id" : "http://lobid.org/resource/HT003759287"
+    "id" : "http://lobid.org/resource/HT003759287"
   } ],
   "contributorLabel" : [ "Schmidt, Eckhard" ],
   "contributorOrder" : [ "http://d-nb.info/gnd/105745944" ],
   "coverage" : [ "Rheine" ],
   "creator" : [ {
-    "@id" : "http://d-nb.info/gnd/105745944",
+    "id" : "http://d-nb.info/gnd/105745944",
     "preferredName" : "Schmidt, Eckhard",
     "preferredNameForThePerson" : "Schmidt, Eckhard"
   } ],
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/BT000040377/about",
     "dateCreated" : "19960814",
-    "dateModified" : "19960814"
+    "dateModified" : "19960814",
+    "id" : "http://lobid.org/resource/BT000040377/about"
   } ],
   "hbzId" : [ "BT000040377" ],
+  "id" : "http://lobid.org/resource/BT000040377",
   "isPartOf" : [ {
-    "@id" : "http://lobid.org/resource/HT003759287"
+    "id" : "http://lobid.org/resource/HT003759287"
   } ],
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DBT000040377"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DBT000040377"
   } ],
   "issued" : [ "1983" ],
   "medium" : [ {
-    "@id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
+    "id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
   } ],
   "nwbibsubject" : [ {
-    "@id" : "http://purl.org/lobid/nwbib#s584060"
+    "id" : "http://purl.org/lobid/nwbib#s584060"
   } ],
   "publicationStatement" : [ "1983" ],
   "sameAs" : [ {
-    "@id" : "http://hub.culturegraph.org/resource/HBZ-BT000040377"
+    "id" : "http://hub.culturegraph.org/resource/HBZ-BT000040377"
   } ],
   "subjectChain" : [ "Vogelschutz | Rheine", "Rheine | Vogelschutz" ],
   "subjectOrder" : [ "Rheine, Vogelschutz", "Vogelschutz, Rheine" ],
   "title" : [ "Die Vogelwelt der Stadt Rheine." ],
-  "type" : [ {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  }, {
-    "@id" : "http://purl.org/ontology/bibo/Article"
-  } ]
+  "type" : [ "http://purl.org/ontology/bibo/Article", "http://purl.org/dc/terms/BibliographicResource" ]
 }

--- a/src/test/resources/output/json/00004/BT000041593.json
+++ b/src/test/resources/output/json/00004/BT000041593.json
@@ -1,51 +1,47 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/BT000041593",
   "bibliographicCitation" : [ "Wirtschaftsspiegel. - 38 (1983) H. 7, S. 24-25 : 1 Abb." ],
   "collectedBy" : [ {
-    "@id" : "http://lobid.org/resource/NWBib"
+    "id" : "http://lobid.org/resource/NWBib"
   } ],
   "containedIn" : [ {
-    "@id" : "http://lobid.org/resource/HT007751353"
+    "id" : "http://lobid.org/resource/HT007751353"
   } ],
   "contributorLabel" : [ "Altekamp, Heinrich" ],
   "contributorOrder" : [ "http://d-nb.info/gnd/10880724X" ],
   "coverage" : [ "Coesfeld (Kreis)" ],
   "creator" : [ {
-    "@id" : "http://d-nb.info/gnd/10880724X",
+    "id" : "http://d-nb.info/gnd/10880724X",
     "preferredName" : "Altekamp, Heinrich",
     "preferredNameForThePerson" : "Altekamp, Heinrich"
   } ],
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/BT000041593/about",
     "dateCreated" : "19960814",
-    "dateModified" : "19960814"
+    "dateModified" : "19960814",
+    "id" : "http://lobid.org/resource/BT000041593/about"
   } ],
   "hbzId" : [ "BT000041593" ],
+  "id" : "http://lobid.org/resource/BT000041593",
   "isPartOf" : [ {
-    "@id" : "http://lobid.org/resource/HT007751353"
+    "id" : "http://lobid.org/resource/HT007751353"
   } ],
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DBT000041593"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DBT000041593"
   } ],
   "issued" : [ "1983" ],
   "medium" : [ {
-    "@id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
+    "id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
   } ],
   "nwbibspatial" : [ {
-    "@id" : "http://purl.org/lobid/nwbib-spatial#n97"
+    "id" : "http://purl.org/lobid/nwbib-spatial#n97"
   } ],
   "nwbibsubject" : [ {
-    "@id" : "http://purl.org/lobid/nwbib#s543000"
+    "id" : "http://purl.org/lobid/nwbib#s543000"
   } ],
   "publicationStatement" : [ "1983" ],
   "sameAs" : [ {
-    "@id" : "http://hub.culturegraph.org/resource/HBZ-BT000041593"
+    "id" : "http://hub.culturegraph.org/resource/HBZ-BT000041593"
   } ],
   "title" : [ "Das Portrait einer Region: Kreis Coesfeld." ],
-  "type" : [ {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  }, {
-    "@id" : "http://purl.org/ontology/bibo/Article"
-  } ]
+  "type" : [ "http://purl.org/ontology/bibo/Article", "http://purl.org/dc/terms/BibliographicResource" ]
 }

--- a/src/test/resources/output/json/00006/BT000067443.json
+++ b/src/test/resources/output/json/00006/BT000067443.json
@@ -1,52 +1,48 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/BT000067443",
   "bibliographicCitation" : [ "Kiebitz. - 6 (1986), S. 29-36, S. 63-67" ],
   "collectedBy" : [ {
-    "@id" : "http://lobid.org/resource/NWBib"
+    "id" : "http://lobid.org/resource/NWBib"
   } ],
   "containedIn" : [ {
-    "@id" : "http://lobid.org/resource/HT006990419"
+    "id" : "http://lobid.org/resource/HT006990419"
   } ],
   "contributorLabel" : [ "Meier, Elmar" ],
   "contributorOrder" : [ "http://d-nb.info/gnd/118033948" ],
   "coverage" : [ "Coesfeld (Kreis)" ],
   "creator" : [ {
-    "@id" : "http://d-nb.info/gnd/118033948",
+    "id" : "http://d-nb.info/gnd/118033948",
     "preferredName" : "Meier, Elmar",
     "preferredNameForThePerson" : "Meier, Elmar"
   } ],
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/BT000067443/about",
     "dateCreated" : "19960816",
-    "dateModified" : "19960816"
+    "dateModified" : "19960816",
+    "id" : "http://lobid.org/resource/BT000067443/about"
   } ],
   "hbzId" : [ "BT000067443" ],
+  "id" : "http://lobid.org/resource/BT000067443",
   "isPartOf" : [ {
-    "@id" : "http://lobid.org/resource/HT006990419"
+    "id" : "http://lobid.org/resource/HT006990419"
   } ],
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DBT000067443"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DBT000067443"
   } ],
   "issued" : [ "1986" ],
   "medium" : [ {
-    "@id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
+    "id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
   } ],
   "nwbibspatial" : [ {
-    "@id" : "http://purl.org/lobid/nwbib-spatial#n97"
+    "id" : "http://purl.org/lobid/nwbib-spatial#n97"
   } ],
   "nwbibsubject" : [ {
-    "@id" : "http://purl.org/lobid/nwbib#s163060"
+    "id" : "http://purl.org/lobid/nwbib#s163060"
   } ],
   "otherTitleInformation" : [ "Vergleichsunters. zu e. Erfassung aus d. Jahre 1976." ],
   "publicationStatement" : [ "1986" ],
   "sameAs" : [ {
-    "@id" : "http://hub.culturegraph.org/resource/HBZ-BT000067443"
+    "id" : "http://hub.culturegraph.org/resource/HBZ-BT000067443"
   } ],
   "title" : [ "Bestandsaufnahme der Amphibien im Raum Coesfeld-Billerbeck" ],
-  "type" : [ {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  }, {
-    "@id" : "http://purl.org/ontology/bibo/Article"
-  } ]
+  "type" : [ "http://purl.org/ontology/bibo/Article", "http://purl.org/dc/terms/BibliographicResource" ]
 }

--- a/src/test/resources/output/json/00007/TT000075751.json
+++ b/src/test/resources/output/json/00007/TT000075751.json
@@ -1,78 +1,72 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/TT000075751",
   "contributor" : [ {
-    "@id" : "http://d-nb.info/gnd/134926277",
+    "id" : "http://d-nb.info/gnd/134926277",
     "preferredName" : "Ogden, Craig",
     "preferredNameForThePerson" : "Ogden, Craig"
   }, {
-    "@id" : "http://d-nb.info/gnd/134769236",
+    "id" : "http://d-nb.info/gnd/134769236",
     "preferredName" : "Martineau, Malcolm",
     "preferredNameForThePerson" : "Martineau, Malcolm"
   }, {
-    "@id" : "http://d-nb.info/gnd/134845323",
+    "id" : "http://d-nb.info/gnd/134845323",
     "preferredName" : "Lewis, Bryn",
     "preferredNameForThePerson" : "Lewis, Bryn"
   } ],
   "contributorLabel" : [ "Britten, Edward B.", "Britten, Edward Benjamin", "Martineau, Malcolm", "Nathan, Regina", "Britten, Benjamin", "McDougall, Jamie", "Anderson, Lorna", "Mac Dougall, Jamie", "Britten, ...", "MacDougall, Jamie", "Ogden, Craig", "Lewis, Bryn" ],
   "contributorOrder" : [ "http://d-nb.info/gnd/118515527 | http://d-nb.info/gnd/13482167X | http://d-nb.info/gnd/134926285 | http://d-nb.info/gnd/134769236 | http://d-nb.info/gnd/134782852 | http://d-nb.info/gnd/134845323 | http://d-nb.info/gnd/134926277" ],
   "creator" : [ {
-    "@id" : "http://d-nb.info/gnd/118515527",
+    "id" : "http://d-nb.info/gnd/118515527",
     "preferredName" : "Britten, Benjamin",
     "preferredNameForThePerson" : "Britten, Benjamin"
   } ],
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/TT000075751/about",
     "dateCreated" : "19990816",
-    "dateModified" : "20120309"
+    "dateModified" : "20120309",
+    "id" : "http://lobid.org/resource/TT000075751/about"
   } ],
   "exemplar" : [ {
-    "@id" : "http://lobid.org/item/TT000075751:DE-Kn38:CD%202410%20-%20CD%202411",
     "callNumber" : "CD 2410 - CD 2411",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/TT000075751:DE-Kn38:CD%202410%20-%20CD%202411/about"
+      "id" : "http://lobid.org/item/TT000075751:DE-Kn38:CD%202410%20-%20CD%202411/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/TT000075751",
+    "id" : "http://lobid.org/item/TT000075751:DE-Kn38:CD%202410%20-%20CD%202411",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Kn38"
+      "id" : "http://lobid.org/organisation/DE-Kn38"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   } ],
   "extent" : [ "2 CD : DDD + Beih." ],
   "hbzId" : [ "TT000075751" ],
+  "id" : "http://lobid.org/resource/TT000075751",
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DTT000075751"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DTT000075751"
   } ],
   "issued" : [ "1994" ],
   "medium" : [ {
-    "@id" : "http://purl.org/ontology/bibo/AudioDocument"
+    "id" : "http://purl.org/ontology/bibo/AudioDocument"
   } ],
   "placeOfPublication" : [ "London" ],
   "publicationStatement" : [ "London; Hyperion; 1994" ],
   "publisher" : [ "Hyperion" ],
   "sameAs" : [ {
-    "@id" : "http://hub.culturegraph.org/resource/HBZ-TT000075751"
+    "id" : "http://hub.culturegraph.org/resource/HBZ-TT000075751"
   } ],
   "singer" : [ {
-    "@id" : "http://d-nb.info/gnd/13482167X",
+    "id" : "http://d-nb.info/gnd/13482167X",
     "preferredName" : "Anderson, Lorna",
     "preferredNameForThePerson" : "Anderson, Lorna"
   }, {
-    "@id" : "http://d-nb.info/gnd/134782852",
+    "id" : "http://d-nb.info/gnd/134782852",
     "preferredName" : "MacDougall, Jamie",
     "preferredNameForThePerson" : "MacDougall, Jamie"
   }, {
-    "@id" : "http://d-nb.info/gnd/134926285",
+    "id" : "http://d-nb.info/gnd/134926285",
     "preferredName" : "Nathan, Regina",
     "preferredNameForThePerson" : "Nathan, Regina"
   } ],
   "statementOfResponsibility" : [ "Benjamin Britten. Lorna Anderson, soprano ; Regina Nathan, soprano ; Jamie MacDougall, tenor ; Malcolm Martineau, piano ; Bryn Lewis, harp ; Craig Ogden, guitar" ],
   "title" : [ "Complete folk song arrangements" ],
-  "type" : [ {
-    "@id" : "http://purl.org/lobid/lv#Miscellaneous"
-  }, {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  } ]
+  "type" : [ "http://purl.org/dc/terms/BibliographicResource", "http://purl.org/lobid/lv#Miscellaneous" ]
 }

--- a/src/test/resources/output/json/00012/BT000128754.json
+++ b/src/test/resources/output/json/00012/BT000128754.json
@@ -1,53 +1,53 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/BT000128754",
   "abstract" : [ "Erinnerungen an d. 1. FC Köln u. Borussia Mönchengladbach" ],
   "bibliographicCitation" : [ "Nach dem Spiel ist vor dem Spiel : die wunderbare Welt des Fußballs / Wolfgang Frank (Hg.); Orig.-Ausg.; 1996; S. 101-[108]" ],
   "collectedBy" : [ {
-    "@id" : "http://lobid.org/resource/NWBib"
+    "id" : "http://lobid.org/resource/NWBib"
   } ],
   "containedIn" : [ {
-    "@id" : "http://lobid.org/resource/HT007138775"
+    "id" : "http://lobid.org/resource/HT007138775"
   } ],
   "contributorLabel" : [ "Job, Bertram" ],
   "contributorOrder" : [ "http://d-nb.info/gnd/174423330" ],
   "coverage" : [ "Köln", "Mönchengladbach" ],
   "creator" : [ {
-    "@id" : "http://d-nb.info/gnd/174423330",
+    "id" : "http://d-nb.info/gnd/174423330",
     "preferredName" : "Job, Bertram",
     "preferredNameForThePerson" : "Job, Bertram"
   } ],
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/BT000128754/about",
     "dateCreated" : "19970106",
-    "dateModified" : "20090401"
+    "dateModified" : "20090401",
+    "id" : "http://lobid.org/resource/BT000128754/about"
   } ],
   "hbzId" : [ "BT000128754" ],
+  "id" : "http://lobid.org/resource/BT000128754",
   "isPartOf" : [ {
-    "@id" : "http://lobid.org/resource/HT007138775"
+    "id" : "http://lobid.org/resource/HT007138775"
   } ],
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DBT000128754"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DBT000128754"
   } ],
   "issued" : [ "1996" ],
   "medium" : [ {
-    "@id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
+    "id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
   } ],
   "nwbibsubject" : [ {
-    "@id" : "http://purl.org/lobid/nwbib#s736050"
+    "id" : "http://purl.org/lobid/nwbib#s736050"
   } ],
   "otherTitleInformation" : [ "Jugend zwischen zwei Magnetpolen ; nur Animosität gebiert große Spiele" ],
   "placeOfPublication" : [ "Reinbek bei Hamburg" ],
   "publicationStatement" : [ "1996; Reinbek bei Hamburg" ],
   "sameAs" : [ {
-    "@id" : "http://hub.culturegraph.org/resource/HBZ-BT000128754"
+    "id" : "http://hub.culturegraph.org/resource/HBZ-BT000128754"
   } ],
   "subject" : [ {
-    "@id" : "http://d-nb.info/gnd/2041907-7",
+    "id" : "http://d-nb.info/gnd/2041907-7",
     "preferredName" : "Verein für Leibesübungen Borussia 1900 Mönchengladbach",
     "preferredNameForTheCorporateBody" : "Verein für Leibesübungen Borussia 1900 Mönchengladbach"
   }, {
-    "@id" : "http://d-nb.info/gnd/2050419-6",
+    "id" : "http://d-nb.info/gnd/2050419-6",
     "preferredName" : "1. Fußball-Club Köln 01/07",
     "preferredNameForTheCorporateBody" : "1. Fußball-Club Köln 01/07"
   } ],
@@ -55,9 +55,5 @@
   "subjectLabel" : [ "1. FC Köln 01/07", "1. Fußball-Club Köln 01/07 e.V.", "Erster Fußball-Club Köln 01/07", "Erster FC Köln", "Borussia Mönchengladbach", "Erster Fußball-Klub Köln 01/07", "1. FC Köln", "VfL Borussia Mönchengladbach" ],
   "subjectOrder" : [ "http://d-nb.info/gnd/2050419-6, Geschichte", "http://d-nb.info/gnd/2041907-7, Geschichte" ],
   "title" : [ "Alle Böcke beißen oder in Feindschaft fest" ],
-  "type" : [ {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  }, {
-    "@id" : "http://purl.org/ontology/bibo/Article"
-  } ]
+  "type" : [ "http://purl.org/ontology/bibo/Article", "http://purl.org/dc/terms/BibliographicResource" ]
 }

--- a/src/test/resources/output/json/00029/HT000290078.json
+++ b/src/test/resources/output/json/00029/HT000290078.json
@@ -1,66 +1,58 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/HT000290078",
   "contributor" : [ {
-    "@id" : "http://d-nb.info/gnd/174737203",
+    "id" : "http://d-nb.info/gnd/174737203",
     "preferredName" : "Aigner, Johann",
     "preferredNameForThePerson" : "Aigner, Johann"
   } ],
   "contributorLabel" : [ "Aigner, Johann" ],
   "contributorOrder" : [ "http://d-nb.info/gnd/174737203" ],
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/HT000290078/about",
     "dateCreated" : "19840831",
-    "dateModified" : "20070718"
+    "dateModified" : "20070718",
+    "id" : "http://lobid.org/resource/HT000290078/about"
   } ],
   "exemplar" : [ {
-    "@id" : "http://lobid.org/item/HT000290078:DE-467:11DCX1513%2B1",
-    "callNumber" : "11DCX1513+1",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT000290078:DE-467:11DCX1513%2B1/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT000290078",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-467"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT000290078:DE-290:Jc%20F%2016826",
     "callNumber" : "Jc F 16826",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT000290078:DE-290:Jc%20F%2016826/about"
+      "id" : "http://lobid.org/item/HT000290078:DE-290:Jc%20F%2016826/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT000290078",
+    "id" : "http://lobid.org/item/HT000290078:DE-290:Jc%20F%2016826",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-290"
+      "id" : "http://lobid.org/organisation/DE-290"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "11DCX1513+1",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT000290078:DE-467:11DCX1513%2B1/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT000290078",
+    "id" : "http://lobid.org/item/HT000290078:DE-467:11DCX1513%2B1",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-467"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   } ],
   "extent" : [ "X, 99 S. : GRAPH. DARST." ],
   "hbzId" : [ "HT000290078" ],
+  "id" : "http://lobid.org/resource/HT000290078",
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT000290078"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT000290078"
   } ],
   "isbn" : [ "3209001731", "9783209001733" ],
   "issued" : [ "1976" ],
   "medium" : [ {
-    "@id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
+    "id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
   } ],
   "otherTitleInformation" : [ "NEUE GRAMMATIK IM DEUTSCHUNTERRICHT FUER 10 - 15JAEHRIGE : E. HANDBUCH FUER D. LEHRER ; FACHLICHE ANREGUNGEN U. PRAKTISCHE BEISPIELE MIT VERWENDUNG D. SATZFIGUREN / VERF. VON E. ARBEITSGEMEINSCHAFT IM RAHMEN D. OESTERR. VERSUCHSSCHULWESENS: JOHANN AIGNER .." ],
   "placeOfPublication" : [ "WIEN", "GRAZ" ],
   "publicationStatement" : [ "WIEN; HOELDER-PICHLER-TEMPSKY; GRAZ; LEYKAM; 1976" ],
   "publisher" : [ "LEYKAM", "HOELDER-PICHLER-TEMPSKY" ],
   "sameAs" : [ {
-    "@id" : "http://hub.culturegraph.org/resource/HBZ-HT000290078"
+    "id" : "http://hub.culturegraph.org/resource/HBZ-HT000290078"
   } ],
   "title" : [ "NEUE GRAMMATIK IM DEUTSCHUNTERRICHT FUER- ZEHN- BIS FUENFZEHNJAEHRIGE" ],
-  "type" : [ {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  }, {
-    "@id" : "http://purl.org/ontology/bibo/Book"
-  } ]
+  "type" : [ "http://purl.org/ontology/bibo/Book", "http://purl.org/dc/terms/BibliographicResource" ]
 }

--- a/src/test/resources/output/json/00121/TT001210514.json
+++ b/src/test/resources/output/json/00121/TT001210514.json
@@ -1,57 +1,49 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/TT001210514",
   "contributorLabel" : [ "Hitler, Adolfo", "Hitler, Adolf", "Xitler, Adolf", "Hitorâ, Adorufu", "Hitler, Adolphe", "Hitlar", "Hitlers, Adolphs", "Gitler, Adol'f", "Gitler, ...", "Hitler, Adolph", "Chitler, Adolphu", "Hitler, ...", "Hitlers, Ādolfs", "Chitler, Adolf", "Hitlar, Adūlf" ],
   "contributorOrder" : [ "http://d-nb.info/gnd/118551655" ],
   "creator" : [ {
-    "@id" : "http://d-nb.info/gnd/118551655",
+    "id" : "http://d-nb.info/gnd/118551655",
     "preferredName" : "Hitler, Adolf",
     "preferredNameForThePerson" : "Hitler, Adolf"
   } ],
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/TT001210514/about",
     "dateCreated" : "20051110",
-    "dateModified" : "20060207"
+    "dateModified" : "20060207",
+    "id" : "http://lobid.org/resource/TT001210514/about"
   } ],
   "edition" : [ "Ausgabe in Blindenschrift" ],
   "exemplar" : [ {
-    "@id" : "http://lobid.org/item/TT001210514:DE-107:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/TT001210514:DE-107:/about"
+      "id" : "http://lobid.org/item/TT001210514:DE-107:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/TT001210514",
+    "id" : "http://lobid.org/item/TT001210514:DE-107:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-107"
+      "id" : "http://lobid.org/organisation/DE-107"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   } ],
   "hbzId" : [ "TT001210514" ],
+  "id" : "http://lobid.org/resource/TT001210514",
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DTT001210514"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DTT001210514"
   } ],
   "language" : [ {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
   } ],
   "medium" : [ {
-    "@id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
+    "id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
   }, {
-    "@id" : "http://purl.org/library/BrailleBook"
+    "id" : "http://purl.org/library/BrailleBook"
   } ],
   "placeOfPublication" : [ "Marburg/Lahn" ],
   "publicationStatement" : [ "Marburg/Lahn; Blindenhochschulbücherei" ],
   "publisher" : [ "Blindenhochschulbücherei" ],
   "sameAs" : [ {
-    "@id" : "http://hub.culturegraph.org/resource/HBZ-TT001210514"
+    "id" : "http://hub.culturegraph.org/resource/HBZ-TT001210514"
   } ],
   "statementOfResponsibility" : [ "von Adolf Hitler" ],
   "title" : [ "Mein Kampf" ],
-  "type" : [ {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  }, {
-    "@id" : "http://purl.org/ontology/bibo/Book"
-  }, {
-    "@id" : "http://purl.org/ontology/bibo/MultiVolumeBook"
-  } ]
+  "type" : [ "http://purl.org/ontology/bibo/Book", "http://purl.org/ontology/bibo/MultiVolumeBook", "http://purl.org/dc/terms/BibliographicResource" ]
 }

--- a/src/test/resources/output/json/00123/TT001230001.json
+++ b/src/test/resources/output/json/00123/TT001230001.json
@@ -1,77 +1,69 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/TT001230001",
   "contributor" : [ {
-    "@id" : "http://d-nb.info/gnd/118577018",
+    "id" : "http://d-nb.info/gnd/118577018",
     "preferredName" : "Manfredi, Sicilia, Re",
     "preferredNameForThePerson" : "Manfredi, Sicilia, Re"
   } ],
   "contributorLabel" : [ "Friderichus secundus", "Friedrich", "Fridericus", "Federicus", "Alberto", "Bolstadius, Albertus", "Federico", "Frédéric", "Manfredo", "Fredericus", "Ps.-Albertus", "Manfredi", "Manfredus", "Albert", "Stupor mundi", "Friderichus", "Manfred", "Frederick", "Albertus", "Phreiderikos", "Magnus, Albertus", "Pseudo-Albertus", "Albertus Magnus", "Friedrich II.", "Petrus" ],
   "contributorOrder" : [ "http://d-nb.info/gnd/118535765 | http://d-nb.info/gnd/118577018 | http://d-nb.info/gnd/118637649" ],
   "creator" : [ {
-    "@id" : "http://d-nb.info/gnd/118637649",
+    "id" : "http://d-nb.info/gnd/118637649",
     "preferredName" : "Albertus, Magnus",
     "preferredNameForThePerson" : "Albertus, Magnus"
   }, {
-    "@id" : "http://d-nb.info/gnd/118535765",
+    "id" : "http://d-nb.info/gnd/118535765",
     "preferredName" : "Friedrich, II., Heiliges Römisches Reich, Kaiser",
     "preferredNameForThePerson" : "Friedrich, II., Heiliges Römisches Reich, Kaiser"
   } ],
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/TT001230001/about",
-    "dateCreated" : "20051110"
+    "dateCreated" : "20051110",
+    "id" : "http://lobid.org/resource/TT001230001/about"
   } ],
   "edition" : [ "Ex membranis vetustis nunc primùm edita" ],
   "exemplar" : [ {
-    "@id" : "http://lobid.org/item/TT001230001:DE-107:MF%20275%2FF2001%2FF2003",
     "callNumber" : "MF 275/F2001/F2003",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/TT001230001:DE-107:MF%20275%2FF2001%2FF2003/about"
+      "id" : "http://lobid.org/item/TT001230001:DE-107:MF%20275%2FF2001%2FF2003/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/TT001230001",
+    "id" : "http://lobid.org/item/TT001230001:DE-107:MF%20275%2FF2001%2FF2003",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-107"
+      "id" : "http://lobid.org/organisation/DE-107"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   } ],
   "extent" : [ "[8] Bl., 414, [1] S. : Ill." ],
   "hbzId" : [ "TT001230001" ],
+  "id" : "http://lobid.org/resource/TT001230001",
   "inSeries" : [ {
     "numbering" : "F2001/F2003]",
     "series" : [ {
-      "@id" : "http://lobid.org/resource/TT001197763"
+      "id" : "http://lobid.org/resource/TT001197763"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/lobid/lv#SeriesRelation"
-    } ]
+    "type" : [ "http://purl.org/lobid/lv#SeriesRelation" ]
   } ],
   "isPartOf" : [ {
-    "@id" : "http://lobid.org/resource/TT001197763"
+    "id" : "http://lobid.org/resource/TT001197763"
   } ],
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DTT001230001"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DTT001230001"
   } ],
   "issued" : [ "1596" ],
   "language" : [ {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/lat"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/lat"
   } ],
   "medium" : [ {
-    "@id" : "http://rdvocab.info/termList/RDACarrierType/1020"
+    "id" : "http://rdvocab.info/termList/RDACarrierType/1020"
   } ],
   "otherTitleInformation" : [ "Cvm Manfredi Regis additionibus", "Reliqva Librorvm Friderici II. Imperatoris, De arte venandi cum auibus" ],
   "placeOfPublication" : [ "Avgvstae Vindelicorvm" ],
   "publicationStatement" : [ "Avgvstae Vindelicorvm; Praetorius; 1596" ],
   "publisher" : [ "Praetorius" ],
   "sameAs" : [ {
-    "@id" : "http://hub.culturegraph.org/resource/HBZ-TT001230001"
+    "id" : "http://hub.culturegraph.org/resource/HBZ-TT001230001"
   } ],
   "title" : [ "Reliqua librorum Friderici II. ... de arte venandi cum avibus" ],
-  "type" : [ {
-    "@id" : "http://purl.org/lobid/lv#Miscellaneous"
-  }, {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  } ],
+  "type" : [ "http://purl.org/dc/terms/BibliographicResource", "http://purl.org/lobid/lv#Miscellaneous" ],
   "volume" : [ "F2001/F2003]" ]
 }

--- a/src/test/resources/output/json/00131/HT001310215.json
+++ b/src/test/resources/output/json/00131/HT001310215.json
@@ -1,56 +1,50 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/HT001310215",
   "contributingCorporateBodyLabel" : [ "Dental Association", "ADA", "American Dental Association" ],
   "contributor" : [ {
-    "@id" : "http://d-nb.info/gnd/177572388",
+    "id" : "http://d-nb.info/gnd/177572388",
     "preferredName" : "SCHOLLE, ROGER H.",
     "preferredNameForThePerson" : "SCHOLLE, ROGER H."
   } ],
   "contributorLabel" : [ "SCHOLLE, ROGER H." ],
   "contributorOrder" : [ "http://d-nb.info/gnd/177572388 | http://d-nb.info/gnd/37460-X" ],
   "creator" : [ {
-    "@id" : "http://d-nb.info/gnd/37460-X",
+    "id" : "http://d-nb.info/gnd/37460-X",
     "preferredName" : "American Dental Association",
     "preferredNameForTheCorporateBody" : "American Dental Association"
   } ],
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/HT001310215/about",
-    "dateCreated" : "19950206"
+    "dateCreated" : "19950206",
+    "id" : "http://lobid.org/resource/HT001310215/about"
   } ],
   "exemplar" : [ {
-    "@id" : "http://lobid.org/item/HT001310215:DE-294:ZMC134",
     "callNumber" : "ZMC134",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT001310215:DE-294:ZMC134/about"
+      "id" : "http://lobid.org/item/HT001310215:DE-294:ZMC134/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT001310215",
+    "id" : "http://lobid.org/item/HT001310215:DE-294:ZMC134",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-294"
+      "id" : "http://lobid.org/organisation/DE-294"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   } ],
   "hbzId" : [ "HT001310215" ],
+  "id" : "http://lobid.org/resource/HT001310215",
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT001310215"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT001310215"
   } ],
   "issued" : [ "1980 - " ],
   "medium" : [ {
-    "@id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
+    "id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
   } ],
   "otherTitleInformation" : [ "THE JOURNAL OF THE AMERICAN DENTAL ASSOCIATION / ED.: ROGER H. SCHOLLE" ],
   "placeOfPublication" : [ "CHICAGO, ILL." ],
   "publicationStatement" : [ "CHICAGO, ILL.; AMERICAN DENTAL ASSOCIATION; 1980" ],
   "publisher" : [ "AMERICAN DENTAL ASSOCIATION" ],
   "sameAs" : [ {
-    "@id" : "http://hub.culturegraph.org/resource/HBZ-HT001310215"
+    "id" : "http://hub.culturegraph.org/resource/HBZ-HT001310215"
   } ],
   "title" : [ "JOURNAL" ],
-  "type" : [ {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  }, {
-    "@id" : "http://purl.org/ontology/bibo/Journal"
-  } ]
+  "type" : [ "http://purl.org/ontology/bibo/Journal", "http://purl.org/dc/terms/BibliographicResource" ]
 }

--- a/src/test/resources/output/json/00167/TT001671747.json
+++ b/src/test/resources/output/json/00167/TT001671747.json
@@ -1,144 +1,130 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/TT001671747",
   "contributingCorporateBodyLabel" : [ "Geographische Kommission für Westfalen", "Provinzialinstitut für Westfälische Landes- und Volksforschung" ],
   "contributor" : [ {
-    "@id" : "http://d-nb.info/gnd/2056181-7",
+    "id" : "http://d-nb.info/gnd/2056181-7",
     "preferredName" : "Provinzialinstitut für Westfälische Landes- und Volksforschung. Geographische Kommission für Westfalen",
     "preferredNameForTheCorporateBody" : "Provinzialinstitut für Westfälische Landes- und Volksforschung. Geographische Kommission für Westfalen"
   } ],
   "contributorLabel" : [ "Mayr, A.", "Mayr, Alois" ],
   "contributorOrder" : [ "http://d-nb.info/gnd/137082479 | http://d-nb.info/gnd/2056181-7" ],
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/TT001671747/about",
     "dateCreated" : "20060407",
-    "dateModified" : "20131108"
+    "dateModified" : "20131108",
+    "id" : "http://lobid.org/resource/TT001671747/about"
   } ],
   "exemplar" : [ {
-    "@id" : "http://lobid.org/item/TT001671747:DE-929:K%2091%2F30:3,5,1",
-    "callNumber" : "K 91/30:3,5,1",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/TT001671747:DE-929:K%2091%2F30:3,5,1/about"
+      "id" : "http://lobid.org/item/TT001671747:DE-466:GOA%207%2F62-3,5,1/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/TT001671747",
+    "id" : "http://lobid.org/item/TT001671747:DE-466:GOA%207%2F62-3,5,1",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-929"
+      "id" : "http://lobid.org/organisation/DE-466"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/TT001671747:DE-290:GOA%207%2F62-3,5,1",
     "callNumber" : "GOA 7/62-3,5,1",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/TT001671747:DE-290:GOA%207%2F62-3,5,1/about"
+      "id" : "http://lobid.org/item/TT001671747:DE-290:GOA%207%2F62-3,5,1/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/TT001671747",
+    "id" : "http://lobid.org/item/TT001671747:DE-290:GOA%207%2F62-3,5,1",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-290"
+      "id" : "http://lobid.org/organisation/DE-290"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/TT001671747:DE-6:GOA%207%2F62-3,5,1",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/TT001671747:DE-6:GOA%207%2F62-3,5,1/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/TT001671747",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-6"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/TT001671747:DE-6-139a:C%20367,V",
     "callNumber" : "C 367,V",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/TT001671747:DE-6-139a:C%20367,V/about"
+      "id" : "http://lobid.org/item/TT001671747:DE-6-139a:C%20367,V/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/TT001671747",
+    "id" : "http://lobid.org/item/TT001671747:DE-6-139a:C%20367,V",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-6-139a"
+      "id" : "http://lobid.org/organisation/DE-6-139a"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/TT001671747:DE-386:GOA%207%2F62-3,5,1",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/TT001671747:DE-386:GOA%207%2F62-3,5,1/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/TT001671747",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-386"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/TT001671747:DE-466:GOA%207%2F62-3,5,1",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/TT001671747:DE-466:GOA%207%2F62-3,5,1/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/TT001671747",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-466"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/TT001671747:DE-Sol1:FN%2066",
     "callNumber" : "FN 66",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/TT001671747:DE-Sol1:FN%2066/about"
+      "id" : "http://lobid.org/item/TT001671747:DE-Sol1:FN%2066/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/TT001671747",
+    "id" : "http://lobid.org/item/TT001671747:DE-Sol1:FN%2066",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Sol1"
+      "id" : "http://lobid.org/organisation/DE-Sol1"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/TT001671747:DE-386:GOA%207%2F62-3,5,1/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/TT001671747",
+    "id" : "http://lobid.org/item/TT001671747:DE-386:GOA%207%2F62-3,5,1",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-386"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "K 91/30:3,5,1",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/TT001671747:DE-929:K%2091%2F30:3,5,1/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/TT001671747",
+    "id" : "http://lobid.org/item/TT001671747:DE-929:K%2091%2F30:3,5,1",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-929"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/TT001671747:DE-6:GOA%207%2F62-3,5,1/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/TT001671747",
+    "id" : "http://lobid.org/item/TT001671747:DE-6:GOA%207%2F62-3,5,1",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-6"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   } ],
   "extent" : [ "[2] Bl. : graph. Darst., Kt." ],
   "hbzId" : [ "TT001671747" ],
+  "id" : "http://lobid.org/resource/TT001671747",
   "isPartOf" : [ {
-    "@id" : "http://lobid.org/resource/HT002808565"
+    "id" : "http://lobid.org/resource/HT002808565"
   } ],
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DTT001671747"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DTT001671747"
   } ],
   "isbn" : [ "9783402061749", "3402061740" ],
   "issued" : [ "1990" ],
   "language" : [ {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
   } ],
   "medium" : [ {
-    "@id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
+    "id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
   }, {
-    "@id" : "http://purl.org/ontology/bibo/Map"
+    "id" : "http://purl.org/ontology/bibo/Map"
   } ],
   "placeOfPublication" : [ "Münster" ],
   "publicationStatement" : [ "Münster; Aschendorff; 1990" ],
   "publisher" : [ "Aschendorff" ],
   "redaktor" : [ {
-    "@id" : "http://d-nb.info/gnd/137082479",
+    "id" : "http://d-nb.info/gnd/137082479",
     "preferredName" : "Mayr, Alois",
     "preferredNameForThePerson" : "Mayr, Alois"
   } ],
   "sameAs" : [ {
-    "@id" : "http://hub.culturegraph.org/resource/HBZ-TT001671747"
+    "id" : "http://hub.culturegraph.org/resource/HBZ-TT001671747"
   } ],
   "statementOfResponsibility" : [ "hrsg. durch den Landschaftsverband Westfalen-Lippe, Geographische Kommission für Westfalen. Atlasred., wiss. und kartograph. Betreuung: Alois Mayr ..." ],
   "subject" : [ {
-    "@id" : "http://d-nb.info/gnd/4073972-7",
+    "id" : "http://d-nb.info/gnd/4073972-7",
     "preferredName" : "Landeskunde",
     "preferredNameForTheSubjectHeading" : "Landeskunde"
   }, {
-    "@id" : "http://d-nb.info/gnd/4065781-4",
+    "id" : "http://d-nb.info/gnd/4065781-4",
     "preferredName" : "Westfalen",
     "preferredNameForThePlaceOrGeographicName" : "Westfalen"
   } ],
@@ -146,19 +132,13 @@
   "subjectLabel" : [ "Regionalkunde", "Westfalen (Volk, Neuzeit)", "Herzogtum Westfalen", "Westfalen (Provinzialverband)", "Provinz Westfalen" ],
   "subjectOrder" : [ "http://d-nb.info/gnd/4065781-4, http://d-nb.info/gnd/4073972-7, Atlas" ],
   "title" : [ "Geographisch-landeskundlicher Atlas von Westfalen, 3,5,1: Bevölkerungsdichte der Gemeinden 1871 - 1987 und Veränderung 1818 - 1987" ],
-  "type" : [ {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  }, {
-    "@id" : "http://purl.org/ontology/bibo/Book"
-  } ],
+  "type" : [ "http://purl.org/ontology/bibo/Book", "http://purl.org/dc/terms/BibliographicResource" ],
   "volume" : [ "Doppelbl. 1", "3,5,1", "Themenbereich 3, Bevölkerung", "Lfg. 5" ],
   "volumeIn" : [ {
     "multiVolumeWork" : [ {
-      "@id" : "http://lobid.org/resource/HT002808565"
+      "id" : "http://lobid.org/resource/HT002808565"
     } ],
     "numbering" : "3,5,1",
-    "type" : [ {
-      "@id" : "http://purl.org/lobid/lv#MultiVolumeWorkRelation"
-    } ]
+    "type" : [ "http://purl.org/lobid/lv#MultiVolumeWorkRelation" ]
   } ]
 }

--- a/src/test/resources/output/json/00172/TT001726537.json
+++ b/src/test/resources/output/json/00172/TT001726537.json
@@ -1,69 +1,61 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/TT001726537",
   "contributor" : [ {
-    "@id" : "http://d-nb.info/gnd/115541802",
+    "id" : "http://d-nb.info/gnd/115541802",
     "preferredName" : "Maimbourg, Louis",
     "preferredNameForThePerson" : "Maimbourg, Louis"
   } ],
   "contributorLabel" : [ "Maimbourg, Lewis", "Maimbourg, Louis", "Maimburgo, Luigi", "Romain, François", "Maimburgius, Ludovicus", "Maimbourg, ...", "Maimburg, Ludwig", "Maimburgus, Ludovicus" ],
   "contributorOrder" : [ "http://d-nb.info/gnd/115541802" ],
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/TT001726537/about",
     "dateCreated" : "20060512",
-    "dateModified" : "20131121"
+    "dateModified" : "20131121",
+    "id" : "http://lobid.org/resource/TT001726537/about"
   } ],
   "exemplar" : [ {
-    "@id" : "http://lobid.org/item/TT001726537:DE-Kn28:2%20in:%20Aa%202422",
     "callNumber" : "2 in: Aa 2422",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/TT001726537:DE-Kn28:2%20in:%20Aa%202422/about"
+      "id" : "http://lobid.org/item/TT001726537:DE-Kn28:2%20in:%20Aa%202422/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/TT001726537",
+    "id" : "http://lobid.org/item/TT001726537:DE-Kn28:2%20in:%20Aa%202422",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Kn28"
+      "id" : "http://lobid.org/organisation/DE-Kn28"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/TT001726537:DE-Kn28:2%20in:%20Aa%201801",
     "callNumber" : "2 in: Aa 1801",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/TT001726537:DE-Kn28:2%20in:%20Aa%201801/about"
+      "id" : "http://lobid.org/item/TT001726537:DE-Kn28:2%20in:%20Aa%201801/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/TT001726537",
+    "id" : "http://lobid.org/item/TT001726537:DE-Kn28:2%20in:%20Aa%201801",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Kn28"
+      "id" : "http://lobid.org/organisation/DE-Kn28"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   } ],
   "extent" : [ "[2] Bl., 116 S. : Ill. (Kupfert.)" ],
   "hbzId" : [ "TT001726537" ],
+  "id" : "http://lobid.org/resource/TT001726537",
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DTT001726537"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DTT001726537"
   } ],
   "issued" : [ "1683" ],
   "language" : [ {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/fra"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/fra"
   } ],
   "medium" : [ {
-    "@id" : "http://rdvocab.info/termList/prodManuscript/1002"
+    "id" : "http://rdvocab.info/termList/prodManuscript/1002"
   }, {
-    "@id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
+    "id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
   } ],
   "placeOfPublication" : [ "Cologne [i.e.] Amsterdam" ],
   "publicationStatement" : [ "Cologne [i.e.] Amsterdam; Delpeuck; 1683" ],
   "publisher" : [ "Delpeuck" ],
   "sameAs" : [ {
-    "@id" : "http://hub.culturegraph.org/resource/HBZ-TT001726537"
+    "id" : "http://hub.culturegraph.org/resource/HBZ-TT001726537"
   } ],
   "title" : [ "Critique Du Jesuite Secularisé" ],
-  "type" : [ {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  }, {
-    "@id" : "http://purl.org/ontology/bibo/Book"
-  } ]
+  "type" : [ "http://purl.org/ontology/bibo/Book", "http://purl.org/dc/terms/BibliographicResource" ]
 }

--- a/src/test/resources/output/json/00189/HT001898812.json
+++ b/src/test/resources/output/json/00189/HT001898812.json
@@ -1,287 +1,251 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/HT001898812",
   "contributor" : [ {
-    "@id" : "http://d-nb.info/gnd/177005009",
+    "id" : "http://d-nb.info/gnd/177005009",
     "preferredName" : "Piprek, Jan",
     "preferredNameForThePerson" : "Piprek, Jan"
   }, {
-    "@id" : "http://d-nb.info/gnd/124515312",
+    "id" : "http://d-nb.info/gnd/124515312",
     "preferredName" : "Ippoldt, Juliusz",
     "preferredNameForThePerson" : "Ippoldt, Juliusz"
   } ],
   "contributorLabel" : [ "Ippoldt, Juliusz", "Ippoldt, Juljusz", "Piprek, Jan" ],
   "contributorOrder" : [ "http://d-nb.info/gnd/177005009 | http://d-nb.info/gnd/124515312" ],
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/HT001898812/about",
     "dateCreated" : "19970903",
-    "dateModified" : "20030610"
+    "dateModified" : "20030610",
+    "id" : "http://lobid.org/resource/HT001898812/about"
   } ],
   "exemplar" : [ {
-    "@id" : "http://lobid.org/item/HT001898812:DE-6:3G%2026297A-2",
-    "callNumber" : "3G 26297A-2",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT001898812:DE-6:3G%2026297A-2/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT001898812",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-6"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT001898812:DE-5:71%2F6301%20(2)",
-    "callNumber" : "71/6301 (2)",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT001898812:DE-5:71%2F6301%20(2)/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT001898812",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-5"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT001898812:DE-466:GYB1007-2",
-    "callNumber" : "GYB1007-2",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT001898812:DE-466:GYB1007-2/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT001898812",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-466"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT001898812:DE-6:3G%2026297-2",
-    "callNumber" : "3G 26297-2",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT001898812:DE-6:3G%2026297-2/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT001898812",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-6"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT001898812:DE-6-033:Ch%20PIPREK%20gro%20pol%202",
     "callNumber" : "Ch PIPREK gro pol 2",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT001898812:DE-6-033:Ch%20PIPREK%20gro%20pol%202/about"
+      "id" : "http://lobid.org/item/HT001898812:DE-6-033:Ch%20PIPREK%20gro%20pol%202/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT001898812",
+    "id" : "http://lobid.org/item/HT001898812:DE-6-033:Ch%20PIPREK%20gro%20pol%202",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-6-033"
+      "id" : "http://lobid.org/organisation/DE-6-033"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT001898812:DE-5:71%2F6301%20(2)%20%232",
-    "callNumber" : "71/6301 (2) #2",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT001898812:DE-5:71%2F6301%20(2)%20%232/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT001898812",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-5"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT001898812:DE-61-28:hisa320.p777(2)",
-    "callNumber" : "hisa320.p777(2)",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT001898812:DE-61-28:hisa320.p777(2)/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT001898812",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-61-28"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT001898812:DE-98:V,%2018809%20(2)",
-    "callNumber" : "V, 18809 (2)",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT001898812:DE-98:V,%2018809%20(2)/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT001898812",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-98"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT001898812:DE-6-249:1%20c%2033",
-    "callNumber" : "1 c 33",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT001898812:DE-6-249:1%20c%2033/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT001898812",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-6-249"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT001898812:DE-385:BF.P645%2Fa2695-2",
-    "callNumber" : "BF.P645/a2695-2",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT001898812:DE-385:BF.P645%2Fa2695-2/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT001898812",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-385"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT001898812:DE-361:NP701.35%20G8D4P%5B2,2",
-    "callNumber" : "NP701.35 G8D4P[2,2",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT001898812:DE-361:NP701.35%20G8D4P%5B2,2/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT001898812",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-361"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT001898812:DE-466:AAE1058-2",
-    "callNumber" : "AAE1058-2",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT001898812:DE-466:AAE1058-2/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT001898812",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-466"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT001898812:DE-294:LLB3272-2",
-    "callNumber" : "LLB3272-2",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT001898812:DE-294:LLB3272-2/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT001898812",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-294"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT001898812:DE-5:71%2F6301%20(2)%20%233",
-    "callNumber" : "71/6301 (2) #3",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT001898812:DE-5:71%2F6301%20(2)%20%233/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT001898812",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-5"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT001898812:DE-61:sla%2Fb4953(2)",
     "callNumber" : "sla/b4953(2)",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT001898812:DE-61:sla%2Fb4953(2)/about"
+      "id" : "http://lobid.org/item/HT001898812:DE-61:sla%2Fb4953(2)/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT001898812",
+    "id" : "http://lobid.org/item/HT001898812:DE-61:sla%2Fb4953(2)",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-61"
+      "id" : "http://lobid.org/organisation/DE-61"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT001898812:DE-465:AAEP35-2",
+    "callNumber" : "NP701.35 G8D4P[2,2",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT001898812:DE-361:NP701.35%20G8D4P%5B2,2/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT001898812",
+    "id" : "http://lobid.org/item/HT001898812:DE-361:NP701.35%20G8D4P%5B2,2",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-361"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "71/6301 (2)",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT001898812:DE-5:71%2F6301%20(2)/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT001898812",
+    "id" : "http://lobid.org/item/HT001898812:DE-5:71%2F6301%20(2)",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-5"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "V, 18809 (2)",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT001898812:DE-98:V,%2018809%20(2)/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT001898812",
+    "id" : "http://lobid.org/item/HT001898812:DE-98:V,%2018809%20(2)",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-98"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "BF.P645/a2695-2",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT001898812:DE-385:BF.P645%2Fa2695-2/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT001898812",
+    "id" : "http://lobid.org/item/HT001898812:DE-385:BF.P645%2Fa2695-2",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-385"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "3G 26297-2",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT001898812:DE-6:3G%2026297-2/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT001898812",
+    "id" : "http://lobid.org/item/HT001898812:DE-6:3G%2026297-2",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-6"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "3G 26297A-2",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT001898812:DE-6:3G%2026297A-2/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT001898812",
+    "id" : "http://lobid.org/item/HT001898812:DE-6:3G%2026297A-2",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-6"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "LLB3272-2",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT001898812:DE-294:LLB3272-2/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT001898812",
+    "id" : "http://lobid.org/item/HT001898812:DE-294:LLB3272-2",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-294"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
     "callNumber" : "AAEP35-2",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT001898812:DE-465:AAEP35-2/about"
+      "id" : "http://lobid.org/item/HT001898812:DE-465:AAEP35-2/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT001898812",
+    "id" : "http://lobid.org/item/HT001898812:DE-465:AAEP35-2",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-465"
+      "id" : "http://lobid.org/organisation/DE-465"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT001898812:DE-61:nc%2F01478",
-    "callNumber" : "nc/01478",
+    "callNumber" : "hisa320.p777(2)",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT001898812:DE-61:nc%2F01478/about"
+      "id" : "http://lobid.org/item/HT001898812:DE-61-28:hisa320.p777(2)/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT001898812",
+    "id" : "http://lobid.org/item/HT001898812:DE-61-28:hisa320.p777(2)",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-61"
+      "id" : "http://lobid.org/organisation/DE-61-28"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT001898812:DE-5:71%2F6301%20(2)%20%231",
+    "callNumber" : "71/6301 (2) #2",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT001898812:DE-5:71%2F6301%20(2)%20%232/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT001898812",
+    "id" : "http://lobid.org/item/HT001898812:DE-5:71%2F6301%20(2)%20%232",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-5"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "71/6301 (2) #3",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT001898812:DE-5:71%2F6301%20(2)%20%233/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT001898812",
+    "id" : "http://lobid.org/item/HT001898812:DE-5:71%2F6301%20(2)%20%233",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-5"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
     "callNumber" : "71/6301 (2) #1",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT001898812:DE-5:71%2F6301%20(2)%20%231/about"
+      "id" : "http://lobid.org/item/HT001898812:DE-5:71%2F6301%20(2)%20%231/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT001898812",
+    "id" : "http://lobid.org/item/HT001898812:DE-5:71%2F6301%20(2)%20%231",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-5"
+      "id" : "http://lobid.org/organisation/DE-5"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "nc/01478",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT001898812:DE-61:nc%2F01478/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT001898812",
+    "id" : "http://lobid.org/item/HT001898812:DE-61:nc%2F01478",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-61"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "1 c 33",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT001898812:DE-6-249:1%20c%2033/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT001898812",
+    "id" : "http://lobid.org/item/HT001898812:DE-6-249:1%20c%2033",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-6-249"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "GYB1007-2",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT001898812:DE-466:GYB1007-2/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT001898812",
+    "id" : "http://lobid.org/item/HT001898812:DE-466:GYB1007-2",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-466"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "AAE1058-2",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT001898812:DE-466:AAE1058-2/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT001898812",
+    "id" : "http://lobid.org/item/HT001898812:DE-466:AAE1058-2",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-466"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   } ],
   "extent" : [ "XVIII, 1306 S." ],
   "hbzId" : [ "HT001898812" ],
+  "id" : "http://lobid.org/resource/HT001898812",
   "isPartOf" : [ {
-    "@id" : "http://lobid.org/resource/HT001381485"
+    "id" : "http://lobid.org/resource/HT001381485"
   } ],
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT001898812"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT001898812"
   } ],
   "issued" : [ "1974" ],
   "language" : [ {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/pol"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/pol"
   }, {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
   } ],
   "medium" : [ {
-    "@id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
+    "id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
   } ],
   "placeOfPublication" : [ "Leipzig" ],
   "publicationStatement" : [ "Leipzig; Verl. Enzyklopädie [u.a.]; 1974" ],
   "publisher" : [ "Verl. Enzyklopädie [u.a.]" ],
   "sameAs" : [ {
-    "@id" : "http://hub.culturegraph.org/resource/HBZ-HT001898812"
+    "id" : "http://hub.culturegraph.org/resource/HBZ-HT001898812"
   } ],
   "statementOfResponsibility" : [ "Jan Piprek ..." ],
   "subject" : [ {
-    "@id" : "http://d-nb.info/gnd/4120314-8",
+    "id" : "http://d-nb.info/gnd/4120314-8",
     "preferredName" : "Polnisch",
     "preferredNameForTheSubjectHeading" : "Polnisch"
   }, {
-    "@id" : "http://d-nb.info/gnd/4113292-0",
+    "id" : "http://d-nb.info/gnd/4113292-0",
     "preferredName" : "Deutsch",
     "preferredNameForTheSubjectHeading" : "Deutsch"
   } ],
@@ -289,22 +253,16 @@
   "subjectLabel" : [ "Hochdeutsch", "Polnische Sprache", "Neuhochdeutsch", "Deutsche Sprache" ],
   "subjectOrder" : [ "http://d-nb.info/gnd/4120314-8, http://d-nb.info/gnd/4113292-0" ],
   "tableOfContents" : [ {
-    "@id" : "http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=3362189&custom_att_2=simple_viewer"
+    "id" : "http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=3362189&custom_att_2=simple_viewer"
   } ],
   "title" : [ "Großwörterbuch Polnisch-Deutsch, 2: O - Ż" ],
-  "type" : [ {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  }, {
-    "@id" : "http://purl.org/ontology/bibo/Book"
-  } ],
+  "type" : [ "http://purl.org/ontology/bibo/Book", "http://purl.org/dc/terms/BibliographicResource" ],
   "volume" : [ "2" ],
   "volumeIn" : [ {
     "multiVolumeWork" : [ {
-      "@id" : "http://lobid.org/resource/HT001381485"
+      "id" : "http://lobid.org/resource/HT001381485"
     } ],
     "numbering" : "2",
-    "type" : [ {
-      "@id" : "http://purl.org/lobid/lv#MultiVolumeWorkRelation"
-    } ]
+    "type" : [ "http://purl.org/lobid/lv#MultiVolumeWorkRelation" ]
   } ]
 }

--- a/src/test/resources/output/json/00223/TT002234459.json
+++ b/src/test/resources/output/json/00223/TT002234459.json
@@ -1,75 +1,69 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/TT002234459",
   "contributorLabel" : [ "Kranz, Heinrich", "Müller, Guntram" ],
   "contributorName" : [ "Kranz, Heinrich", "Müller, Guntram" ],
   "contributorOrder" : [ "Kranz, Heinrich | Müller, Guntram" ],
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/TT002234459/about",
     "dateCreated" : "20030718",
-    "dateModified" : "20081017"
+    "dateModified" : "20081017",
+    "id" : "http://lobid.org/resource/TT002234459/about"
   } ],
   "exemplar" : [ {
-    "@id" : "http://lobid.org/item/TT002234459:DE-929:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/TT002234459:DE-929:/about"
+      "id" : "http://lobid.org/item/TT002234459:DE-929:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/TT002234459",
+    "id" : "http://lobid.org/item/TT002234459:DE-929:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-929"
+      "id" : "http://lobid.org/organisation/DE-929"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   } ],
   "fulltextOnline" : [ {
-    "@id" : "http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=1638893&custom_att_2=simple_viewer"
+    "id" : "http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=1638893&custom_att_2=simple_viewer"
   } ],
   "hasVersion" : [ {
-    "@id" : "http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=1638893&custom_att_2=simple_viewer"
+    "id" : "http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=1638893&custom_att_2=simple_viewer"
   } ],
   "hbzId" : [ "TT002234459" ],
+  "id" : "http://lobid.org/resource/TT002234459",
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DTT002234459"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DTT002234459"
   } ],
   "language" : [ {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
   } ],
   "medium" : [ {
-    "@id" : "http://rdvocab.info/termList/RDACarrierType/1018"
+    "id" : "http://rdvocab.info/termList/RDACarrierType/1018"
   }, {
-    "@id" : "http://purl.org/ontology/bibo/Map"
+    "id" : "http://purl.org/ontology/bibo/Map"
   }, {
-    "@id" : "http://rdvocab.info/termList/RDACarrierType/1010"
+    "id" : "http://rdvocab.info/termList/RDACarrierType/1010"
   } ],
   "sameAs" : [ {
-    "@id" : "http://hub.culturegraph.org/resource/HBZ-TT002234459"
+    "id" : "http://hub.culturegraph.org/resource/HBZ-TT002234459"
   } ],
   "similar" : [ {
-    "@id" : "http://nbn-resolving.de/urn:nbn:de:hbz:929:01-2079"
+    "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:929:01-2079"
   } ],
   "subject" : [ {
-    "@id" : "http://d-nb.info/gnd/4114067-9",
+    "id" : "http://d-nb.info/gnd/4114067-9",
     "preferredName" : "Jakobsweg",
     "preferredNameForThePlaceOrGeographicName" : "Jakobsweg"
   }, {
-    "@id" : "http://d-nb.info/gnd/4049787-2",
+    "id" : "http://d-nb.info/gnd/4049787-2",
     "preferredName" : "Rhein-Lahn-Kreis",
     "preferredNameForThePlaceOrGeographicName" : "Rhein-Lahn-Kreis"
   }, {
-    "@id" : "http://dewey.info/class/914/"
+    "id" : "http://dewey.info/class/914/"
   } ],
   "subjectChain" : [ "Rhein-Lahn-Kreis | Jakobsweg | Karte (213)" ],
   "subjectLabel" : [ "Wandern, Diez, Lahnstein, Rhein-Lahn-Info, Rhein, Lahn, Wirtschaftsförderung", "Rhein-Lahn-Kreis / Landratsamt", "Camino de Santiago", "Chemin de Saint Jacques", "Sternenweg", "Rhein-Lahn-Kreis / Kreisverwaltung", "Jakobusweg" ],
   "subjectOrder" : [ "http://d-nb.info/gnd/4049787-2, http://d-nb.info/gnd/4114067-9, Karte" ],
   "title" : [ "Jakobswege : der Lahn-Camino" ],
-  "type" : [ {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  }, {
-    "@id" : "http://purl.org/ontology/bibo/Book"
-  } ],
+  "type" : [ "http://purl.org/ontology/bibo/Book", "http://purl.org/dc/terms/BibliographicResource" ],
   "urn" : [ "urn:nbn:de:hbz:929:01-2079" ],
   "webPageArchived" : [ {
-    "@id" : "http://www.rhein-lahn-info.de/jakobsweg/"
+    "id" : "http://www.rhein-lahn-info.de/jakobsweg/"
   } ]
 }

--- a/src/test/resources/output/json/00261/HT002619538.json
+++ b/src/test/resources/output/json/00261/HT002619538.json
@@ -1,123 +1,109 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/HT002619538",
   "alternativeTitle" : [ "Bulletin annuel de statistiques des transports pour l'Europe et l'Amérique du Nord", "Ežegodnyj bjulleten' statistiki transporta dlja Evropy i Severnoj Ameriki" ],
   "contributingCorporateBodyLabel" : [ "Ėkonomičeskaja Komissija dlja Evropy", "CEE", "Európai Gazdasági Bizottság", "ECE", "Vereinte Nationen", "Commission Economique pour l'Europe", "Wirtschaftskommission für Europa", "Economic Commission for Europe", "Evropejskaja Ėkonomičeskaja Komissija", "Wirtschaftsausschuss für Europa", "Europäische Wirtschaftskommission", "UNECE", "UN-ECE" ],
   "contributor" : [ {
-    "@id" : "http://d-nb.info/gnd/2023669-4",
+    "id" : "http://d-nb.info/gnd/2023669-4",
     "preferredName" : "Vereinte Nationen. Economic Commission for Europe",
     "preferredNameForTheCorporateBody" : "Vereinte Nationen. Economic Commission for Europe"
   } ],
   "contributorOrder" : [ "http://d-nb.info/gnd/2023669-4" ],
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/HT002619538/about",
     "dateCreated" : "19991118",
-    "dateModified" : "20131031"
+    "dateModified" : "20131031",
+    "id" : "http://lobid.org/resource/HT002619538/about"
   } ],
   "exemplar" : [ {
-    "@id" : "http://lobid.org/item/HT002619538:DE-6-260:V%20-%20B%20151",
-    "callNumber" : "V - B 151",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT002619538:DE-6-260:V%20-%20B%20151/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT002619538",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-6-260"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT002619538:DE-38-121:Sh13",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT002619538:DE-38-121:Sh13/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT002619538",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-38-121"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT002619538:DE-38:Sh13",
-    "callNumber" : "Sh13",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT002619538:DE-38:Sh13/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT002619538",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-38"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT002619538:DE-5:Z%204'%2066%2F103",
     "callNumber" : "Z 4' 66/103",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT002619538:DE-5:Z%204'%2066%2F103/about"
+      "id" : "http://lobid.org/item/HT002619538:DE-5:Z%204'%2066%2F103/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT002619538",
+    "id" : "http://lobid.org/item/HT002619538:DE-5:Z%204'%2066%2F103",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-5"
+      "id" : "http://lobid.org/organisation/DE-5"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT002619538:DE-294:ZRC%20828",
     "callNumber" : "ZRC 828",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT002619538:DE-294:ZRC%20828/about"
+      "id" : "http://lobid.org/item/HT002619538:DE-294:ZRC%20828/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT002619538",
+    "id" : "http://lobid.org/item/HT002619538:DE-294:ZRC%20828",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-294"
+      "id" : "http://lobid.org/organisation/DE-294"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "V - B 151",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT002619538:DE-6-260:V%20-%20B%20151/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT002619538",
+    "id" : "http://lobid.org/item/HT002619538:DE-6-260:V%20-%20B%20151",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-6-260"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT002619538:DE-38-121:Sh13/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT002619538",
+    "id" : "http://lobid.org/item/HT002619538:DE-38-121:Sh13",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-38-121"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "Sh13",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT002619538:DE-38:Sh13/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT002619538",
+    "id" : "http://lobid.org/item/HT002619538:DE-38:Sh13",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-38"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   } ],
   "hbzId" : [ "HT002619538" ],
+  "id" : "http://lobid.org/resource/HT002619538",
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT002619538"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT002619538"
   } ],
   "issn" : [ "00663859", "02509911" ],
   "issued" : [ "1955 - 2004" ],
   "language" : [ {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/rus"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/rus"
   }, {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/eng"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/eng"
   }, {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/fra"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/fra"
   } ],
   "medium" : [ {
-    "@id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
+    "id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
   } ],
   "placeOfPublication" : [ "Genève [u.a.]" ],
   "publicationStatement" : [ "Genève [u.a.]; UN; 1955" ],
   "publisher" : [ "UN" ],
   "sameAs" : [ {
-    "@id" : "http://ld.zdb-services.de/resource/1257-9"
+    "id" : "http://ld.zdb-services.de/resource/1257-9"
   }, {
-    "@id" : "http://lobid.org/resource/ZDB1257-9",
     "describedby" : [ {
-      "@id" : "http://lobid.org/resource/ZDB1257-9/about"
+      "id" : "http://lobid.org/resource/ZDB1257-9/about"
     } ],
+    "id" : "http://lobid.org/resource/ZDB1257-9",
     "sameAs" : "http://lobid.org/resource/HT002619538"
   } ],
   "statementOfResponsibility" : [ "Economic Commission for Europe, Transport Division, United Nations" ],
   "subject" : [ {
-    "@id" : "http://dewey.info/class/310/"
+    "id" : "http://dewey.info/class/310/"
   }, {
-    "@id" : "http://dewey.info/class/050/"
+    "id" : "http://dewey.info/class/050/"
   } ],
   "title" : [ "Annual bulletin of transport statistics for Europe and North America" ],
-  "type" : [ {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  }, {
-    "@id" : "http://purl.org/ontology/bibo/Journal"
-  } ],
+  "type" : [ "http://purl.org/ontology/bibo/Journal", "http://purl.org/dc/terms/BibliographicResource" ],
   "zdbId" : [ "1257-9" ]
 }

--- a/src/test/resources/output/json/00301/CT003012479.json
+++ b/src/test/resources/output/json/00301/CT003012479.json
@@ -1,128 +1,122 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/CT003012479",
   "actor" : [ {
-    "@id" : "http://d-nb.info/gnd/141891173",
-    "preferredName" : "BÃ¶hm, Johann, der JÃ¼ngere",
-    "preferredNameForThePerson" : "BÃ¶hm, Johann, der JÃ¼ngere"
-  }, {
-    "@id" : "http://d-nb.info/gnd/14216075X",
-    "preferredName" : "Bilau, Wilhelmine",
-    "preferredNameForThePerson" : "Bilau, Wilhelmine"
-  }, {
-    "@id" : "http://d-nb.info/gnd/118512536",
-    "preferredName" : "BÃ¶hm, Marianne",
-    "preferredNameForThePerson" : "BÃ¶hm, Marianne"
-  }, {
-    "@id" : "http://d-nb.info/gnd/141889810",
-    "preferredName" : "Krug, ...",
-    "preferredNameForThePerson" : "Krug, ..."
-  }, {
-    "@id" : "http://d-nb.info/gnd/1041277814",
-    "preferredName" : "Kellermann, ...",
-    "preferredNameForThePerson" : "Kellermann, ..."
-  }, {
-    "@id" : "http://d-nb.info/gnd/142027901",
-    "preferredName" : "Fuchs, ...",
-    "preferredNameForThePerson" : "Fuchs, ..."
-  }, {
-    "@id" : "http://d-nb.info/gnd/141927135",
+    "id" : "http://d-nb.info/gnd/141927135",
     "preferredName" : "Bilau, Margarete",
     "preferredNameForThePerson" : "Bilau, Margarete"
   }, {
-    "@id" : "http://d-nb.info/gnd/141834919",
+    "id" : "http://d-nb.info/gnd/14216075X",
+    "preferredName" : "Bilau, Wilhelmine",
+    "preferredNameForThePerson" : "Bilau, Wilhelmine"
+  }, {
+    "id" : "http://d-nb.info/gnd/118512536",
+    "preferredName" : "BÃ¶hm, Marianne",
+    "preferredNameForThePerson" : "BÃ¶hm, Marianne"
+  }, {
+    "id" : "http://d-nb.info/gnd/1041277814",
+    "preferredName" : "Kellermann, ...",
+    "preferredNameForThePerson" : "Kellermann, ..."
+  }, {
+    "id" : "http://d-nb.info/gnd/141889810",
+    "preferredName" : "Krug, ...",
+    "preferredNameForThePerson" : "Krug, ..."
+  }, {
+    "id" : "http://d-nb.info/gnd/141891173",
+    "preferredName" : "BÃ¶hm, Johann, der JÃ¼ngere",
+    "preferredNameForThePerson" : "BÃ¶hm, Johann, der JÃ¼ngere"
+  }, {
+    "id" : "http://d-nb.info/gnd/142027901",
+    "preferredName" : "Fuchs, ...",
+    "preferredNameForThePerson" : "Fuchs, ..."
+  }, {
+    "id" : "http://d-nb.info/gnd/141834919",
     "preferredName" : "Dardenne, ...",
     "preferredNameForThePerson" : "Dardenne, ..."
   }, {
-    "@id" : "http://d-nb.info/gnd/142061166",
+    "id" : "http://d-nb.info/gnd/142061166",
     "preferredName" : "Annoni, ...",
     "preferredNameForThePerson" : "Annoni, ..."
   } ],
   "alternativeTitle" : [ "<<La>> Belisa Ossia La FedeltÃ¡ Riconosciuta" ],
   "composer" : [ {
-    "@id" : "http://d-nb.info/gnd/119055716",
+    "id" : "http://d-nb.info/gnd/119055716",
     "preferredName" : "Winter, Peter von",
     "preferredNameForThePerson" : "Winter, Peter von"
   } ],
   "contributingCorporateBodyLabel" : [ "Deutsche Schauspieler-Gesellschaft" ],
   "contributor" : [ {
-    "@id" : "http://d-nb.info/gnd/123633206",
-    "preferredName" : "Pepoli, Alessandro Ercole",
-    "preferredNameForThePerson" : "Pepoli, Alessandro Ercole"
-  }, {
-    "@id" : "http://d-nb.info/gnd/14216075X",
+    "id" : "http://d-nb.info/gnd/14216075X",
     "preferredName" : "Bilau, Wilhelmine",
     "preferredNameForThePerson" : "Bilau, Wilhelmine"
   }, {
-    "@id" : "http://d-nb.info/gnd/116620153",
+    "id" : "http://d-nb.info/gnd/123633206",
+    "preferredName" : "Pepoli, Alessandro Ercole",
+    "preferredNameForThePerson" : "Pepoli, Alessandro Ercole"
+  }, {
+    "id" : "http://d-nb.info/gnd/116620153",
     "preferredName" : "Giesecke, Carl Ludwig von",
     "preferredNameForThePerson" : "Giesecke, Carl Ludwig von"
   }, {
-    "@id" : "http://d-nb.info/gnd/16068028-1",
+    "id" : "http://d-nb.info/gnd/16068028-1",
     "preferredName" : "Deutsche Schauspieler-Gesellschaft <DÃ¼sseldorf>",
     "preferredNameForTheCorporateBody" : "Deutsche Schauspieler-Gesellschaft <DÃ¼sseldorf>"
   } ],
   "contributorLabel" : [ "Dardenne, ...", "Giesecke, Carl Ludwig von", "Winter, Peter", "BÃ¶hm, Marianne", "Krug, ...", "Giesecke, Charles", "Giesecke, Johann George Carl Ludwig", "Mezler, Johann Georg Karl", "Winter, ...", "Pepoli, Alessandro Ercole", "Mezler, Johann G.", "BÃ¶hm, Johann", "Bilau, ...", "Pepoli, Alessandro E.", "Giesecke, Johann G.", "Gieseke, Karl Ludwig", "Gieseke, Karl Ludwig von", "Annoni, ...", "Mezler, Johann Georg", "Giesecke, Johann Georg Karl", "Bilau, Margarete", "Giesecke, Carl", "Giesecke, Karl", "Gieseke, Karl L.", "Giesecke, Charles L.", "Gieseke, Carl Ludwig", "BÃ¶hm, Wilhelmine", "BÃ¶hm, ...", "Fuchs, ...", "Giesecke, Carl Ludwig", "Metzler, Johann Georg von", "Gieseke, Carl Ludwig von", "Giesecke, Karl Ludwig von", "Kellermann, ...", "Giesecke, ...", "Winter, Pietro de", "Giesecke, Ludwig", "Winter, Pietro", "Giesecke, Charles Lewis", "Gieseke, Charles Lewis", "Winter, J. P.", "Giesecke, Carl L.", "Winter, Pierre", "Giesecke, Joh. Georg Karl", "Metzler, Johann Georg Karl", "Metzler, Carl L.", "Bilau, Wilhelmine", "Pepoli, Alessandro", "Winter, Peter von", "Wintter, P.", "Winter, P.", "Gieseke, Carl L.", "Metzler, Johann G.", "Giesecke, J. G. K." ],
   "contributorOrder" : [ "http://d-nb.info/gnd/119055716 | http://d-nb.info/gnd/123633206 | http://d-nb.info/gnd/116620153 | http://d-nb.info/gnd/141927135 | http://d-nb.info/gnd/142027901 | http://d-nb.info/gnd/14216075X | http://d-nb.info/gnd/118512536 | http://d-nb.info/gnd/1041277814 | http://d-nb.info/gnd/141834919 | http://d-nb.info/gnd/141889810 | http://d-nb.info/gnd/142061166 | http://d-nb.info/gnd/141891173 | http://d-nb.info/gnd/16068028-1" ],
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/CT003012479/about",
-    "dateCreated" : "20150420"
+    "dateCreated" : "20150420",
+    "id" : "http://lobid.org/resource/CT003012479/about"
   } ],
   "extent" : [ "1 Plakat : sw ; 33 x 29 cm" ],
   "fulltextOnline" : [ {
-    "@id" : "http://nbn-resolving.de/urn:nbn:de:hbz:061:2-46125"
+    "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:061:2-46125"
   } ],
   "hasVersion" : [ {
-    "@id" : "http://nbn-resolving.de/urn:nbn:de:hbz:061:2-46125"
+    "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:061:2-46125"
   } ],
   "hbzId" : [ "CT003012479" ],
+  "id" : "http://lobid.org/resource/CT003012479",
   "inSeries" : [ {
     "numbering" : "1805,04,17",
     "series" : [ {
-      "@id" : "http://lobid.org/resource/HT017290519"
+      "id" : "http://lobid.org/resource/HT017290519"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/lobid/lv#SeriesRelation"
-    } ]
+    "type" : [ "http://purl.org/lobid/lv#SeriesRelation" ]
   } ],
   "isFormatOf" : [ {
-    "@id" : "http://lobid.org/resource/HT016511663"
+    "id" : "http://lobid.org/resource/HT016511663"
   } ],
   "isPartOf" : [ {
-    "@id" : "http://lobid.org/resource/HT017290519"
+    "id" : "http://lobid.org/resource/HT017290519"
   } ],
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DCT003012479"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DCT003012479"
   } ],
   "issued" : [ "2015", "1805" ],
   "language" : [ {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
   } ],
   "medium" : [ {
-    "@id" : "http://rdvocab.info/termList/RDACarrierType/1018"
+    "id" : "http://rdvocab.info/termList/RDACarrierType/1018"
   }, {
-    "@id" : "http://rdvocab.info/termList/RDACarrierType/1010"
+    "id" : "http://rdvocab.info/termList/RDACarrierType/1010"
   } ],
   "otherTitleInformation" : [ "... wird heute Mittwoch den 17ten April die hier anwesende deutsche Schauspieler-Gesellschaft (Zum Letztenmale) die Ehre haben aufzufÃ¼hren ; Abonnement suspendu ; eine ganz neue groÃe komische Oper in 2 AufzÃ¼gen" ],
   "placeOfPublication" : [ "[DÃ¼sseldorf]" ],
   "publicationStatement" : [ "[DÃ¼sseldorf]; BÃ¶gemann; 1805" ],
   "publisher" : [ "BÃ¶gemann" ],
   "sameAs" : [ {
-    "@id" : "http://hub.culturegraph.org/resource/HBZ-CT003012479"
+    "id" : "http://hub.culturegraph.org/resource/HBZ-CT003012479"
   } ],
   "similar" : [ {
-    "@id" : "http://nbn-resolving.de/urn:nbn:de:hbz:061:2-46125"
+    "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:061:2-46125"
   } ],
   "source" : [ {
-    "@id" : "http://lobid.org/resource/HT016511663"
+    "id" : "http://lobid.org/resource/HT016511663"
   } ],
   "statementOfResponsibility" : [ "die Musik ist von dem berÃ¼hmten Kapellmeister Winter, Compositeur der Oper: Das unterbrochene Opferfest. [Textverf.: Alessandro Ercole Pepoli. Ãbers. und arrang. von Carl Ludwig von Giesecke]. Personen: Madam Bilau, Herr Fuchs, Madam BÃ¶hm d.j., Madam BÃ¶hm d.Ã¤., Herr Kellermann, Herr Dardenne, Herr Krug, Madam Annoni, Herr BÃ¶hm" ],
   "title" : [ "Elise, GrÃ¤finn von Hillburg" ],
-  "type" : [ {
-    "@id" : "http://purl.org/lobid/lv#Miscellaneous"
-  }, {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  } ],
+  "type" : [ "http://purl.org/dc/terms/BibliographicResource", "http://purl.org/lobid/lv#Miscellaneous" ],
   "urn" : [ "urn:nbn:de:hbz:061:2-46125" ],
   "volume" : [ "1805,04,17" ]
 }

--- a/src/test/resources/output/json/00301/CT003012479_.json
+++ b/src/test/resources/output/json/00301/CT003012479_.json
@@ -1,22 +1,18 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/CT003012479_",
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/CT003012479_/about"
+    "id" : "http://lobid.org/resource/CT003012479_/about"
   } ],
   "hbzId" : [ "CT003012479_" ],
+  "id" : "http://lobid.org/resource/CT003012479_",
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DCT003012479_"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DCT003012479_"
   } ],
   "medium" : [ {
-    "@id" : "http://purl.org/lobid/lv#Miscellaneous"
+    "id" : "http://purl.org/lobid/lv#Miscellaneous"
   } ],
   "sameAs" : [ {
-    "@id" : "http://hub.culturegraph.org/resource/HBZ-CT003012479_"
+    "id" : "http://hub.culturegraph.org/resource/HBZ-CT003012479_"
   } ],
-  "type" : [ {
-    "@id" : "http://purl.org/lobid/lv#Miscellaneous"
-  }, {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  } ]
+  "type" : [ "http://purl.org/dc/terms/BibliographicResource", "http://purl.org/lobid/lv#Miscellaneous" ]
 }

--- a/src/test/resources/output/json/00305/TT003059252.json
+++ b/src/test/resources/output/json/00305/TT003059252.json
@@ -1,59 +1,53 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/TT003059252",
   "contributingCorporateBodyLabel" : [ "The Beatles" ],
   "contributor" : [ {
-    "@id" : "http://d-nb.info/gnd/2005535-3",
+    "id" : "http://d-nb.info/gnd/2005535-3",
     "preferredName" : "The Beatles",
     "preferredNameForTheCorporateBody" : "The Beatles"
   } ],
   "contributorOrder" : [ "http://d-nb.info/gnd/2005535-3 | http://d-nb.info/gnd/2005535-3" ],
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/TT003059252/about",
-    "dateCreated" : "20110411"
+    "dateCreated" : "20110411",
+    "id" : "http://lobid.org/resource/TT003059252/about"
   } ],
   "exemplar" : [ {
-    "@id" : "http://lobid.org/item/TT003059252:DE-5-58:9%2F041",
     "callNumber" : "9/041",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/TT003059252:DE-5-58:9%2F041/about"
+      "id" : "http://lobid.org/item/TT003059252:DE-5-58:9%2F041/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/TT003059252",
+    "id" : "http://lobid.org/item/TT003059252:DE-5-58:9%2F041",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-5-58"
+      "id" : "http://lobid.org/organisation/DE-5-58"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   } ],
   "extent" : [ "1 Video (VHS, 55 min.) : farb.; stereo" ],
   "hbzId" : [ "TT003059252" ],
+  "id" : "http://lobid.org/resource/TT003059252",
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DTT003059252"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DTT003059252"
   } ],
   "issued" : [ "1967" ],
   "language" : [ {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/eng"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/eng"
   } ],
   "medium" : [ {
-    "@id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
+    "id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
   }, {
-    "@id" : "http://rdvocab.info/termList/RDACarrierType/1050"
+    "id" : "http://rdvocab.info/termList/RDACarrierType/1050"
   }, {
-    "@id" : "http://purl.org/ontology/bibo/AudioVisualDocument"
+    "id" : "http://purl.org/ontology/bibo/AudioVisualDocument"
   } ],
   "otherTitleInformation" : [ "Magical Mystery Tour" ],
   "placeOfPublication" : [ "s.l." ],
   "publicationStatement" : [ "s.l.; Apple Films; 1967" ],
   "publisher" : [ "Apple Films" ],
   "sameAs" : [ {
-    "@id" : "http://hub.culturegraph.org/resource/HBZ-TT003059252"
+    "id" : "http://hub.culturegraph.org/resource/HBZ-TT003059252"
   } ],
   "statementOfResponsibility" : [ "The Beatles. Produced and Directed by The Beatles." ],
   "title" : [ "The Beatles" ],
-  "type" : [ {
-    "@id" : "http://purl.org/lobid/lv#Miscellaneous"
-  }, {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  } ]
+  "type" : [ "http://purl.org/dc/terms/BibliographicResource", "http://purl.org/lobid/lv#Miscellaneous" ]
 }

--- a/src/test/resources/output/json/00316/HT003160768.json
+++ b/src/test/resources/output/json/00316/HT003160768.json
@@ -1,124 +1,112 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/HT003160768",
   "collectedBy" : [ {
-    "@id" : "http://lobid.org/resource/NWBib"
+    "id" : "http://lobid.org/resource/NWBib"
   } ],
   "contributorOrder" : [ "http://d-nb.info/gnd/2019209-5" ],
   "coverage" : [ "Münster <Westfalen, Bezirk>" ],
   "creator" : [ {
-    "@id" : "http://d-nb.info/gnd/2019209-5",
+    "id" : "http://d-nb.info/gnd/2019209-5",
     "preferredName" : "Regierungsbezirk Münster, Westfalen"
   } ],
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/HT003160768/about",
     "dateCreated" : "19931111",
-    "dateModified" : "20031104"
+    "dateModified" : "20031104",
+    "id" : "http://lobid.org/resource/HT003160768/about"
   } ],
   "exemplar" : [ {
-    "@id" : "http://lobid.org/item/HT003160768:DE-465:ONG%2Fg52127",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT003160768:DE-465:ONG%2Fg52127/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT003160768",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-465"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT003160768:DE-6-210:ONG%2Fg52127",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT003160768:DE-6-210:ONG%2Fg52127/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT003160768",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-6-210"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT003160768:DE-6:ONG%2Fg52127",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT003160768:DE-6:ONG%2Fg52127/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT003160768",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-6"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT003160768:DE-385:ONG%2Fg52127",
     "callNumber" : "ONG/g52127",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT003160768:DE-385:ONG%2Fg52127/about"
+      "id" : "http://lobid.org/item/HT003160768:DE-385:ONG%2Fg52127/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT003160768",
+    "id" : "http://lobid.org/item/HT003160768:DE-385:ONG%2Fg52127",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-385"
+      "id" : "http://lobid.org/organisation/DE-385"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT003160768:DE-6-007:ONG%2Fg52127",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT003160768:DE-6-007:ONG%2Fg52127/about"
+      "id" : "http://lobid.org/item/HT003160768:DE-6-007:ONG%2Fg52127/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT003160768",
+    "id" : "http://lobid.org/item/HT003160768:DE-6-007:ONG%2Fg52127",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-6-007"
+      "id" : "http://lobid.org/organisation/DE-6-007"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT003160768:DE-6-A:ONG%2Fg52127",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT003160768:DE-6-A:ONG%2Fg52127/about"
+      "id" : "http://lobid.org/item/HT003160768:DE-6-210:ONG%2Fg52127/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT003160768",
+    "id" : "http://lobid.org/item/HT003160768:DE-6-210:ONG%2Fg52127",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-6-A"
+      "id" : "http://lobid.org/organisation/DE-6-210"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT003160768:DE-6-A:ONG%2Fg52127/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT003160768",
+    "id" : "http://lobid.org/item/HT003160768:DE-6-A:ONG%2Fg52127",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-6-A"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT003160768:DE-6:ONG%2Fg52127/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT003160768",
+    "id" : "http://lobid.org/item/HT003160768:DE-6:ONG%2Fg52127",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-6"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT003160768:DE-465:ONG%2Fg52127/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT003160768",
+    "id" : "http://lobid.org/item/HT003160768:DE-465:ONG%2Fg52127",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-465"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   } ],
   "hbzId" : [ "HT003160768" ],
+  "id" : "http://lobid.org/resource/HT003160768",
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT003160768"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT003160768"
   } ],
   "issued" : [ "1980 - " ],
   "language" : [ {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
   } ],
   "medium" : [ {
-    "@id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
+    "id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
   } ],
   "nwbibspatial" : [ {
-    "@id" : "http://purl.org/lobid/nwbib-spatial#n96"
+    "id" : "http://purl.org/lobid/nwbib-spatial#n96"
   } ],
   "nwbibsubject" : [ {
-    "@id" : "http://purl.org/lobid/nwbib#s572030"
+    "id" : "http://purl.org/lobid/nwbib#s572030"
   } ],
   "otherTitleInformation" : [ "Regierungsbezirk Münster" ],
   "placeOfPublication" : [ "Münster" ],
   "publicationStatement" : [ "Münster; Der Regierungspräsident; 1980" ],
   "publisher" : [ "Der Regierungspräsident" ],
   "sameAs" : [ {
-    "@id" : "http://hub.culturegraph.org/resource/HBZ-HT003160768"
+    "id" : "http://hub.culturegraph.org/resource/HBZ-HT003160768"
   } ],
   "subject" : [ {
-    "@id" : "http://d-nb.info/gnd/4034268-2",
+    "id" : "http://d-nb.info/gnd/4034268-2",
     "preferredName" : "Landesplanung",
     "preferredNameForTheSubjectHeading" : "Landesplanung"
   }, {
-    "@id" : "http://d-nb.info/gnd/4040613-1",
+    "id" : "http://d-nb.info/gnd/4040613-1",
     "preferredName" : "Bezirk Münster (Westf)",
     "preferredNameForThePlaceOrGeographicName" : "Bezirk Münster (Westf)"
   } ],
@@ -126,11 +114,5 @@
   "subjectLabel" : [ "Gebietsplanung", "Landesentwicklungsplanung", "Münster (Westf) (Bezirk)", "Handwerkskammerbezirk Münster (Westf)" ],
   "subjectOrder" : [ "http://d-nb.info/gnd/4040613-1, http://d-nb.info/gnd/4034268-2" ],
   "title" : [ "Gebietsentwicklungsplan" ],
-  "type" : [ {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  }, {
-    "@id" : "http://purl.org/ontology/bibo/Book"
-  }, {
-    "@id" : "http://purl.org/ontology/bibo/MultiVolumeBook"
-  } ]
+  "type" : [ "http://purl.org/ontology/bibo/Book", "http://purl.org/ontology/bibo/MultiVolumeBook", "http://purl.org/dc/terms/BibliographicResource" ]
 }

--- a/src/test/resources/output/json/00438/HT004381366.json
+++ b/src/test/resources/output/json/00438/HT004381366.json
@@ -1,133 +1,119 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/HT004381366",
   "collectedBy" : [ {
-    "@id" : "http://lobid.org/resource/NWBib"
+    "id" : "http://lobid.org/resource/NWBib"
   } ],
   "contributorOrder" : [ "http://d-nb.info/gnd/2019209-5" ],
   "creator" : [ {
-    "@id" : "http://d-nb.info/gnd/2019209-5",
+    "id" : "http://d-nb.info/gnd/2019209-5",
     "preferredName" : "Regierungsbezirk Münster, Westfalen"
   } ],
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/HT004381366/about",
     "dateCreated" : "19921203",
-    "dateModified" : "20010605"
+    "dateModified" : "20010605",
+    "id" : "http://lobid.org/resource/HT004381366/about"
   } ],
   "exemplar" : [ {
-    "@id" : "http://lobid.org/item/HT004381366:DE-6-007:Sep.%2010.04.01%2F55,5",
-    "callNumber" : "Sep. 10.04.01/55,5",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT004381366:DE-6-007:Sep.%2010.04.01%2F55,5/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT004381366",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-6-007"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT004381366:DE-6-A:MG%2023990%2F1-1",
-    "callNumber" : "MG 23990/1-1",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT004381366:DE-6-A:MG%2023990%2F1-1/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT004381366",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-6-A"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT004381366:DE-6:2C%20583-2",
-    "callNumber" : "2C 583-2",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT004381366:DE-6:2C%20583-2/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT004381366",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-6"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT004381366:DE-6-210:Boe%2070%20-%20%5B2%5D",
     "callNumber" : "Boe 70 - [2]",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT004381366:DE-6-210:Boe%2070%20-%20%5B2%5D/about"
+      "id" : "http://lobid.org/item/HT004381366:DE-6-210:Boe%2070%20-%20%5B2%5D/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT004381366",
+    "id" : "http://lobid.org/item/HT004381366:DE-6-210:Boe%2070%20-%20%5B2%5D",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-6-210"
+      "id" : "http://lobid.org/organisation/DE-6-210"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "MG 23990/1-1",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT004381366:DE-6-A:MG%2023990%2F1-1/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT004381366",
+    "id" : "http://lobid.org/item/HT004381366:DE-6-A:MG%2023990%2F1-1",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-6-A"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "2C 583-2",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT004381366:DE-6:2C%20583-2/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT004381366",
+    "id" : "http://lobid.org/item/HT004381366:DE-6:2C%20583-2",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-6"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "Sep. 10.04.01/55,5",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT004381366:DE-6-007:Sep.%2010.04.01%2F55,5/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT004381366",
+    "id" : "http://lobid.org/item/HT004381366:DE-6-007:Sep.%2010.04.01%2F55,5",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-6-007"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   } ],
   "extent" : [ "117 S. : zahlr. Kt." ],
   "hbzId" : [ "HT004381366" ],
+  "id" : "http://lobid.org/resource/HT004381366",
   "isPartOf" : [ {
-    "@id" : "http://lobid.org/resource/HT003160768"
+    "id" : "http://lobid.org/resource/HT003160768"
   } ],
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT004381366"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT004381366"
   } ],
   "issued" : [ "1986" ],
   "language" : [ {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
   } ],
   "medium" : [ {
-    "@id" : "http://purl.org/lobid/lv#Miscellaneous"
+    "id" : "http://purl.org/lobid/lv#Miscellaneous"
   } ],
   "nwbibspatial" : [ {
-    "@id" : "http://purl.org/lobid/nwbib-spatial#n10"
+    "id" : "http://purl.org/lobid/nwbib-spatial#n10"
   } ],
   "nwbibsubject" : [ {
-    "@id" : "http://purl.org/lobid/nwbib#s572030"
+    "id" : "http://purl.org/lobid/nwbib#s572030"
   } ],
   "placeOfPublication" : [ "Münster" ],
   "publicationStatement" : [ "Münster; Der Regierungspräsident; 1986" ],
   "publisher" : [ "Der Regierungspräsident" ],
   "sameAs" : [ {
-    "@id" : "http://hub.culturegraph.org/resource/HBZ-HT004381366"
+    "id" : "http://hub.culturegraph.org/resource/HBZ-HT004381366"
   } ],
   "subject" : [ {
-    "@id" : "http://d-nb.info/gnd/4034268-2",
+    "id" : "http://d-nb.info/gnd/4034268-2",
     "preferredName" : "Landesplanung",
     "preferredNameForTheSubjectHeading" : "Landesplanung"
   }, {
-    "@id" : "http://d-nb.info/gnd/4040619-2",
+    "id" : "http://d-nb.info/gnd/4040613-1",
+    "preferredName" : "Bezirk Münster (Westf)",
+    "preferredNameForThePlaceOrGeographicName" : "Bezirk Münster (Westf)"
+  }, {
+    "id" : "http://d-nb.info/gnd/4040619-2",
     "preferredName" : "Münsterland",
     "preferredNameForThePlaceOrGeographicName" : "Münsterland"
   }, {
-    "@id" : "http://d-nb.info/gnd/4306876-5",
+    "id" : "http://d-nb.info/gnd/4306876-5",
     "preferredName" : "Regionalplan",
     "preferredNameForTheSubjectHeading" : "Regionalplan"
-  }, {
-    "@id" : "http://d-nb.info/gnd/4040613-1",
-    "preferredName" : "Bezirk Münster (Westf)",
-    "preferredNameForThePlaceOrGeographicName" : "Bezirk Münster (Westf)"
   } ],
   "subjectChain" : [ "Münsterland | Regionalplan | Bezirk Münster (Westf) | Landesplanung (21)" ],
   "subjectLabel" : [ "Gebietsplanung", "Landesentwicklungsplanung", "Regierungsbezirk Münster", "Münster (Westf) (Bezirk)", "Regionaler Raumordnungsplan", "Handwerkskammerbezirk Münster (Westf)", "Gebietsentwicklungsplan", "Regionalentwicklungsplan" ],
   "subjectOrder" : [ "http://d-nb.info/gnd/4040619-2, http://d-nb.info/gnd/4306876-5, http://d-nb.info/gnd/4040613-1, http://d-nb.info/gnd/4034268-2" ],
   "title" : [ "Gebietsentwicklungsplan, Tezemu: Teilabschnitt Zentrales Münsterland" ],
-  "type" : [ {
-    "@id" : "http://purl.org/lobid/lv#Miscellaneous"
-  }, {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  } ],
+  "type" : [ "http://purl.org/dc/terms/BibliographicResource", "http://purl.org/lobid/lv#Miscellaneous" ],
   "volume" : [ "Tezemu", "<Tezemu>" ],
   "volumeIn" : [ {
     "multiVolumeWork" : [ {
-      "@id" : "http://lobid.org/resource/HT003160768"
+      "id" : "http://lobid.org/resource/HT003160768"
     } ],
     "numbering" : "Tezemu",
-    "type" : [ {
-      "@id" : "http://purl.org/lobid/lv#MultiVolumeWorkRelation"
-    } ]
+    "type" : [ "http://purl.org/lobid/lv#MultiVolumeWorkRelation" ]
   } ]
 }

--- a/src/test/resources/output/json/00494/HT004944075.json
+++ b/src/test/resources/output/json/00494/HT004944075.json
@@ -1,77 +1,69 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/HT004944075",
   "contributingCorporateBodyLabel" : [ "Ėkonomičeskaja Komissija dlja Evropy", "CEE", "Európai Gazdasági Bizottság", "ECE", "United Nations", "Commission Economique pour l'Europe", "Wirtschaftskommission für Europa", "Economic Commission for Europe", "Evropejskaja Ėkonomičeskaja Komissija", "Wirtschaftsausschuss für Europa", "Europäische Wirtschaftskommission", "UNECE", "UN-ECE" ],
   "contributor" : [ {
-    "@id" : "http://d-nb.info/gnd/2023669-4",
+    "id" : "http://d-nb.info/gnd/2023669-4",
     "preferredName" : "United Nations. Economic Commission for Europe",
     "preferredNameForTheCorporateBody" : "United Nations. Economic Commission for Europe"
   } ],
   "contributorOrder" : [ "http://d-nb.info/gnd/2023669-4" ],
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/HT004944075/about",
-    "dateCreated" : "19930816"
+    "dateCreated" : "19930816",
+    "id" : "http://lobid.org/resource/HT004944075/about"
   } ],
   "exemplar" : [ {
-    "@id" : "http://lobid.org/item/HT004944075:DE-294:ZRC828-43",
     "callNumber" : "ZRC828-43",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT004944075:DE-294:ZRC828-43/about"
+      "id" : "http://lobid.org/item/HT004944075:DE-294:ZRC828-43/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT004944075",
+    "id" : "http://lobid.org/item/HT004944075:DE-294:ZRC828-43",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-294"
+      "id" : "http://lobid.org/organisation/DE-294"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   } ],
   "hbzId" : [ "HT004944075" ],
+  "id" : "http://lobid.org/resource/HT004944075",
   "isPartOf" : [ {
-    "@id" : "http://ld.zdb-services.de/resource/1257-9"
+    "id" : "http://ld.zdb-services.de/resource/1257-9"
   }, {
-    "@id" : "http://lobid.org/resource/HT002619538"
+    "id" : "http://lobid.org/resource/HT002619538"
   } ],
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT004944075"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT004944075"
   } ],
   "isbn" : [ "9210162765", "9789210162760" ],
   "language" : [ {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/rus"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/rus"
   }, {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/eng"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/eng"
   }, {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/fra"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/fra"
   } ],
   "medium" : [ {
-    "@id" : "http://purl.org/lobid/lv#Miscellaneous"
+    "id" : "http://purl.org/lobid/lv#Miscellaneous"
   } ],
   "placeOfPublication" : [ "Genève [u.a.]" ],
   "publicationStatement" : [ "Genève [u.a.]; UN; 43. 1993" ],
   "publisher" : [ "UN" ],
   "sameAs" : [ {
-    "@id" : "http://hub.culturegraph.org/resource/HBZ-HT004944075"
+    "id" : "http://hub.culturegraph.org/resource/HBZ-HT004944075"
   } ],
   "statementOfResponsibility" : [ "Economic Commission for Europe, Transport Division, United Nations" ],
   "subject" : [ {
-    "@id" : "http://dewey.info/class/310/"
+    "id" : "http://dewey.info/class/310/"
   }, {
-    "@id" : "http://dewey.info/class/050/"
+    "id" : "http://dewey.info/class/050/"
   } ],
   "title" : [ "Annual bulletin of transport statistics for Europe and North America, 43" ],
-  "type" : [ {
-    "@id" : "http://purl.org/lobid/lv#Miscellaneous"
-  }, {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  } ],
+  "type" : [ "http://purl.org/dc/terms/BibliographicResource", "http://purl.org/lobid/lv#Miscellaneous" ],
   "volume" : [ "43. 1993", "43" ],
   "volumeIn" : [ {
     "multiVolumeWork" : [ {
-      "@id" : "http://lobid.org/resource/HT002619538"
+      "id" : "http://lobid.org/resource/HT002619538"
     } ],
     "numbering" : "43",
-    "type" : [ {
-      "@id" : "http://purl.org/lobid/lv#MultiVolumeWorkRelation"
-    } ]
+    "type" : [ "http://purl.org/lobid/lv#MultiVolumeWorkRelation" ]
   } ]
 }

--- a/src/test/resources/output/json/00626/HT006266886.json
+++ b/src/test/resources/output/json/00626/HT006266886.json
@@ -1,80 +1,74 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/HT006266886",
   "actor" : [ {
-    "@id" : "http://d-nb.info/gnd/141618302",
-    "preferredName" : "Capolicchio, Lino",
-    "preferredNameForThePerson" : "Capolicchio, Lino"
-  }, {
-    "@id" : "http://d-nb.info/gnd/120454874",
+    "id" : "http://d-nb.info/gnd/120454874",
     "preferredName" : "Berger, Helmut",
     "preferredNameForThePerson" : "Berger, Helmut"
   }, {
-    "@id" : "http://d-nb.info/gnd/143102893",
+    "id" : "http://d-nb.info/gnd/143102893",
     "preferredName" : "Sanda, Dominique",
     "preferredNameForThePerson" : "Sanda, Dominique"
   }, {
-    "@id" : "http://d-nb.info/gnd/141649429",
+    "id" : "http://d-nb.info/gnd/141618302",
+    "preferredName" : "Capolicchio, Lino",
+    "preferredNameForThePerson" : "Capolicchio, Lino"
+  }, {
+    "id" : "http://d-nb.info/gnd/141649429",
     "preferredName" : "Testi, Fabio",
     "preferredNameForThePerson" : "Testi, Fabio"
   } ],
   "contributor" : [ {
-    "@id" : "http://d-nb.info/gnd/118657496",
+    "id" : "http://d-nb.info/gnd/118657496",
     "preferredName" : "Bassani, Giorgio",
     "preferredNameForThePerson" : "Bassani, Giorgio"
   } ],
   "contributorLabel" : [ "De Sica, Vittorio", "Capolicchio, Lino", "Marchi, Giacomo", "Steinberger, Helmut", "Sica, Vittorio de", "Bassani, Giorgio", "Sanda, Dominique", "Testi, Fabio", "Varaigne, Dominique", "Berger, Helmut", "Basani, G'org'o", "DeSica, Vittorio" ],
   "contributorOrder" : [ "http://d-nb.info/gnd/118677942 | http://d-nb.info/gnd/118657496 | http://d-nb.info/gnd/143102893 | http://d-nb.info/gnd/141618302 | http://d-nb.info/gnd/141649429 | http://d-nb.info/gnd/120454874" ],
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/HT006266886/about",
     "dateCreated" : "19981218",
-    "dateModified" : "20021108"
+    "dateModified" : "20021108",
+    "id" : "http://lobid.org/resource/HT006266886/about"
   } ],
   "director" : [ {
-    "@id" : "http://d-nb.info/gnd/118677942",
+    "id" : "http://d-nb.info/gnd/118677942",
     "preferredName" : "De Sica, Vittorio",
     "preferredNameForThePerson" : "De Sica, Vittorio"
   } ],
   "exemplar" : [ {
-    "@id" : "http://lobid.org/item/HT006266886:DE-467:Medienzentrum",
     "callNumber" : "Medienzentrum",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT006266886:DE-467:Medienzentrum/about"
+      "id" : "http://lobid.org/item/HT006266886:DE-467:Medienzentrum/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT006266886",
+    "id" : "http://lobid.org/item/HT006266886:DE-467:Medienzentrum",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-467"
+      "id" : "http://lobid.org/organisation/DE-467"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   } ],
   "extent" : [ "1 Videokassette (VHS, 93 Min.) : farb." ],
   "hbzId" : [ "HT006266886" ],
+  "id" : "http://lobid.org/resource/HT006266886",
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT006266886"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT006266886"
   } ],
   "issued" : [ "1992" ],
   "language" : [ {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/ita"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/ita"
   } ],
   "medium" : [ {
-    "@id" : "http://rdvocab.info/termList/RDACarrierType/1050"
+    "id" : "http://rdvocab.info/termList/RDACarrierType/1050"
   }, {
-    "@id" : "http://purl.org/ontology/bibo/AudioVisualDocument"
+    "id" : "http://purl.org/ontology/bibo/AudioVisualDocument"
   } ],
   "placeOfPublication" : [ "Segrate (Milano)" ],
   "publicationStatement" : [ "Segrate (Milano); Mondadori Video; 1992" ],
   "publisher" : [ "Mondadori Video" ],
   "sameAs" : [ {
-    "@id" : "http://hub.culturegraph.org/resource/HBZ-HT006266886"
+    "id" : "http://hub.culturegraph.org/resource/HBZ-HT006266886"
   } ],
   "statementOfResponsibility" : [ "Regia: Vittorio DeSica. Interpreti: Dominique Sanda ; Lino Capolicchio ; Fabio Testi ; Helmut Berger" ],
   "title" : [ "Il giardino dei Finzi-Contini" ],
   "titleKeyword" : [ "Finzi Contini" ],
-  "type" : [ {
-    "@id" : "http://purl.org/lobid/lv#Miscellaneous"
-  }, {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  } ]
+  "type" : [ "http://purl.org/dc/terms/BibliographicResource", "http://purl.org/lobid/lv#Miscellaneous" ]
 }

--- a/src/test/resources/output/json/00971/HT009719670.json
+++ b/src/test/resources/output/json/00971/HT009719670.json
@@ -1,64 +1,58 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/HT009719670",
   "contributor" : [ {
-    "@id" : "http://d-nb.info/gnd/11860225X",
-    "preferredName" : "Rohmer, Eric",
-    "preferredNameForThePerson" : "Rohmer, Eric"
+    "id" : "http://d-nb.info/gnd/133991210",
+    "preferredName" : "Salins, Geneviève-Dominique de",
+    "preferredNameForThePerson" : "Salins, Geneviève-Dominique de"
   }, {
-    "@id" : "http://d-nb.info/gnd/172026644",
+    "id" : "http://d-nb.info/gnd/172026644",
     "preferredName" : "Courtillon, Janine",
     "preferredNameForThePerson" : "Courtillon, Janine"
   }, {
-    "@id" : "http://d-nb.info/gnd/133991210",
-    "preferredName" : "Salins, Geneviève-Dominique de",
-    "preferredNameForThePerson" : "Salins, Geneviève-Dominique de"
+    "id" : "http://d-nb.info/gnd/11860225X",
+    "preferredName" : "Rohmer, Eric",
+    "preferredNameForThePerson" : "Rohmer, Eric"
   } ],
   "contributorLabel" : [ "Courtillon, Janine", "Scherer, Maurice Jean-Marie", "Scherer, Henri Joseph", "Schérer, Henri Maurice Joseph", "Schérer, Maurice Henri Joseph", "Rohmer, Eric", "Schérer, Jean-Marie Maurice", "Scherer, Maurice", "Courtillon, J.", "Salins, Geneviève-Dominique de", "Cordier, Gilbert", "Salins, G. D. de" ],
   "contributorOrder" : [ "http://d-nb.info/gnd/172026644 | http://d-nb.info/gnd/133991210 | http://d-nb.info/gnd/11860225X" ],
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/HT009719670/about",
     "dateCreated" : "19990222",
-    "dateModified" : "20050117"
+    "dateModified" : "20050117",
+    "id" : "http://lobid.org/resource/HT009719670/about"
   } ],
   "exemplar" : [ {
-    "@id" : "http://lobid.org/item/HT009719670:DE-467:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT009719670:DE-467:/about"
+      "id" : "http://lobid.org/item/HT009719670:DE-467:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT009719670",
+    "id" : "http://lobid.org/item/HT009719670:DE-467:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-467"
+      "id" : "http://lobid.org/organisation/DE-467"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   } ],
   "frequency" : [ "Erschienen: 1 - 2, jeweils Videokass. u. Begleith." ],
   "hbzId" : [ "HT009719670" ],
+  "id" : "http://lobid.org/resource/HT009719670",
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT009719670"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT009719670"
   } ],
   "language" : [ {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/fra"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/fra"
   } ],
   "medium" : [ {
-    "@id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
+    "id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
   }, {
-    "@id" : "http://iflastandards.info/ns/isbd/terms/mediatype/T1008"
+    "id" : "http://iflastandards.info/ns/isbd/terms/mediatype/T1008"
   } ],
   "otherTitleInformation" : [ "extraits de films de Eric Rohmer" ],
   "placeOfPublication" : [ "Paris" ],
   "publicationStatement" : [ "Paris; Hatier/Didier" ],
   "publisher" : [ "Hatier/Didier" ],
   "sameAs" : [ {
-    "@id" : "http://hub.culturegraph.org/resource/HBZ-HT009719670"
+    "id" : "http://hub.culturegraph.org/resource/HBZ-HT009719670"
   } ],
   "statementOfResponsibility" : [ "sélectionnés par Janine Courtillon et Geneviève-Dominique de Salins" ],
   "title" : [ "Le cinéma de la vie" ],
-  "type" : [ {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  }, {
-    "@id" : "http://purl.org/ontology/bibo/MultiVolumeBook"
-  } ]
+  "type" : [ "http://purl.org/ontology/bibo/MultiVolumeBook", "http://purl.org/dc/terms/BibliographicResource" ]
 }

--- a/src/test/resources/output/json/01066/HT010662586.json
+++ b/src/test/resources/output/json/01066/HT010662586.json
@@ -1,50 +1,44 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/HT010662586",
   "contributorLabel" : [ "Wedgwood, Cicely Veronica", "Wedgwood, Veronica", "C.", "Wedgwood, Cicely V.", "Wedgwood, C. V." ],
   "contributorOrder" : [ "http://d-nb.info/gnd/118839055" ],
   "creator" : [ {
-    "@id" : "http://d-nb.info/gnd/118839055",
+    "id" : "http://d-nb.info/gnd/118839055",
     "preferredName" : "Wedgwood, Cicely V.",
     "preferredNameForThePerson" : "Wedgwood, Cicely V."
   } ],
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/HT010662586/about",
-    "dateCreated" : "19990818"
+    "dateCreated" : "19990818",
+    "id" : "http://lobid.org/resource/HT010662586/about"
   } ],
   "exemplar" : [ {
-    "@id" : "http://lobid.org/item/HT010662586:DE-380:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT010662586:DE-380:/about"
+      "id" : "http://lobid.org/item/HT010662586:DE-380:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT010662586",
+    "id" : "http://lobid.org/item/HT010662586:DE-380:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-380"
+      "id" : "http://lobid.org/organisation/DE-380"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   } ],
   "extent" : [ "23 p." ],
   "hbzId" : [ "HT010662586" ],
+  "id" : "http://lobid.org/resource/HT010662586",
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT010662586"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT010662586"
   } ],
   "issued" : [ "1957" ],
   "medium" : [ {
-    "@id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
+    "id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
   } ],
   "placeOfPublication" : [ "[S.l.]" ],
   "publicationStatement" : [ "[S.l.]; Leicester Univ. Pr.; 1957" ],
   "publisher" : [ "Leicester Univ. Pr." ],
   "sameAs" : [ {
-    "@id" : "http://hub.culturegraph.org/resource/HBZ-HT010662586"
+    "id" : "http://hub.culturegraph.org/resource/HBZ-HT010662586"
   } ],
   "statementOfResponsibility" : [ "by C[icely] V[eronica] Wedgwood" ],
   "title" : [ "The Common man in the great Civil War" ],
-  "type" : [ {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  }, {
-    "@id" : "http://purl.org/ontology/bibo/Book"
-  } ]
+  "type" : [ "http://purl.org/ontology/bibo/Book", "http://purl.org/dc/terms/BibliographicResource" ]
 }

--- a/src/test/resources/output/json/01072/HT010726584.json
+++ b/src/test/resources/output/json/01072/HT010726584.json
@@ -1,459 +1,393 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/HT010726584",
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/HT010726584/about",
     "dateCreated" : "19991122",
-    "dateModified" : "20131031"
+    "dateModified" : "20131031",
+    "id" : "http://lobid.org/resource/HT010726584/about"
   } ],
   "exemplar" : [ {
-    "@id" : "http://lobid.org/item/HT010726584:DE-5:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT010726584:DE-5:/about"
+      "id" : "http://lobid.org/item/HT010726584:DE-468:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT010726584",
+    "id" : "http://lobid.org/item/HT010726584:DE-468:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-5"
+      "id" : "http://lobid.org/organisation/DE-468"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT010726584:DE-107:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT010726584:DE-107:/about"
+      "id" : "http://lobid.org/item/HT010726584:DE-929:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT010726584",
+    "id" : "http://lobid.org/item/HT010726584:DE-929:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-107"
+      "id" : "http://lobid.org/organisation/DE-929"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT010726584:DE-38M:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT010726584:DE-38M:/about"
+      "id" : "http://lobid.org/item/HT010726584:DE-Kob7:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT010726584",
+    "id" : "http://lobid.org/item/HT010726584:DE-Kob7:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-38M"
+      "id" : "http://lobid.org/organisation/DE-Kob7"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT010726584:DE-465:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT010726584:DE-465:/about"
+      "id" : "http://lobid.org/item/HT010726584:DE-1044:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT010726584",
+    "id" : "http://lobid.org/item/HT010726584:DE-1044:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-465"
+      "id" : "http://lobid.org/organisation/DE-1044"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT010726584:DE-Kob7:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT010726584:DE-Kob7:/about"
+      "id" : "http://lobid.org/item/HT010726584:DE-51:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT010726584",
+    "id" : "http://lobid.org/item/HT010726584:DE-51:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Kob7"
+      "id" : "http://lobid.org/organisation/DE-51"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT010726584:DE-1044:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT010726584:DE-1044:/about"
+      "id" : "http://lobid.org/item/HT010726584:DE-294:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT010726584",
+    "id" : "http://lobid.org/item/HT010726584:DE-294:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-1044"
+      "id" : "http://lobid.org/organisation/DE-294"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT010726584:DE-929:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT010726584:DE-929:/about"
+      "id" : "http://lobid.org/item/HT010726584:DE-Due62:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT010726584",
+    "id" : "http://lobid.org/item/HT010726584:DE-Due62:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-929"
+      "id" : "http://lobid.org/organisation/DE-Due62"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT010726584:DE-82:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT010726584:DE-82:/about"
+      "id" : "http://lobid.org/item/HT010726584:DE-Lan1:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT010726584",
+    "id" : "http://lobid.org/item/HT010726584:DE-Lan1:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-82"
+      "id" : "http://lobid.org/organisation/DE-Lan1"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT010726584:DE-708:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT010726584:DE-708:/about"
+      "id" : "http://lobid.org/item/HT010726584:DE-1383:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT010726584",
+    "id" : "http://lobid.org/item/HT010726584:DE-1383:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-708"
+      "id" : "http://lobid.org/organisation/DE-1383"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT010726584:DE-51:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT010726584:DE-51:/about"
+      "id" : "http://lobid.org/item/HT010726584:DE-465:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT010726584",
+    "id" : "http://lobid.org/item/HT010726584:DE-465:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-51"
+      "id" : "http://lobid.org/organisation/DE-465"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT010726584:DE-Lan1:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT010726584:DE-Lan1:/about"
+      "id" : "http://lobid.org/item/HT010726584:DE-466:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT010726584",
+    "id" : "http://lobid.org/item/HT010726584:DE-466:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Lan1"
+      "id" : "http://lobid.org/organisation/DE-466"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT010726584:DE-386:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT010726584:DE-386:/about"
+      "id" : "http://lobid.org/item/HT010726584:DE-1010:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT010726584",
+    "id" : "http://lobid.org/item/HT010726584:DE-1010:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-386"
+      "id" : "http://lobid.org/organisation/DE-1010"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT010726584:DE-1383:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT010726584:DE-1383:/about"
+      "id" : "http://lobid.org/item/HT010726584:DE-361:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT010726584",
+    "id" : "http://lobid.org/item/HT010726584:DE-361:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-1383"
+      "id" : "http://lobid.org/organisation/DE-361"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT010726584:DE-361:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT010726584:DE-361:/about"
+      "id" : "http://lobid.org/item/HT010726584:DE-708:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT010726584",
+    "id" : "http://lobid.org/item/HT010726584:DE-708:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-361"
+      "id" : "http://lobid.org/organisation/DE-708"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT010726584:DE-1010:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT010726584:DE-1010:/about"
+      "id" : "http://lobid.org/item/HT010726584:DE-38M:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT010726584",
+    "id" : "http://lobid.org/item/HT010726584:DE-38M:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-1010"
+      "id" : "http://lobid.org/organisation/DE-38M"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT010726584:DE-294:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT010726584:DE-294:/about"
+      "id" : "http://lobid.org/item/HT010726584:DE-5:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT010726584",
+    "id" : "http://lobid.org/item/HT010726584:DE-5:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-294"
+      "id" : "http://lobid.org/organisation/DE-5"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT010726584:DE-Due62:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT010726584:DE-Due62:/about"
+      "id" : "http://lobid.org/item/HT010726584:DE-467:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT010726584",
+    "id" : "http://lobid.org/item/HT010726584:DE-467:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Due62"
+      "id" : "http://lobid.org/organisation/DE-467"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT010726584:DE-466:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT010726584:DE-466:/about"
+      "id" : "http://lobid.org/item/HT010726584:DE-829:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT010726584",
+    "id" : "http://lobid.org/item/HT010726584:DE-829:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-466"
+      "id" : "http://lobid.org/organisation/DE-829"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT010726584:DE-468:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT010726584:DE-468:/about"
+      "id" : "http://lobid.org/item/HT010726584:DE-836:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT010726584",
+    "id" : "http://lobid.org/item/HT010726584:DE-836:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-468"
+      "id" : "http://lobid.org/organisation/DE-836"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT010726584:DE-290:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT010726584:DE-290:/about"
+      "id" : "http://lobid.org/item/HT010726584:DE-290:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT010726584",
+    "id" : "http://lobid.org/item/HT010726584:DE-290:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-290"
+      "id" : "http://lobid.org/organisation/DE-290"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT010726584:DE-6:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT010726584:DE-6:/about"
+      "id" : "http://lobid.org/item/HT010726584:DE-Bi10:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT010726584",
+    "id" : "http://lobid.org/item/HT010726584:DE-Bi10:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-6"
+      "id" : "http://lobid.org/organisation/DE-Bi10"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT010726584:DE-61:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT010726584:DE-61:/about"
+      "id" : "http://lobid.org/item/HT010726584:DE-385:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT010726584",
+    "id" : "http://lobid.org/item/HT010726584:DE-385:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-61"
+      "id" : "http://lobid.org/organisation/DE-385"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT010726584:DE-385:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT010726584:DE-385:/about"
+      "id" : "http://lobid.org/item/HT010726584:DE-38:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT010726584",
+    "id" : "http://lobid.org/item/HT010726584:DE-38:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-385"
+      "id" : "http://lobid.org/organisation/DE-38"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT010726584:DE-829:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT010726584:DE-829:/about"
+      "id" : "http://lobid.org/item/HT010726584:DE-61:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT010726584",
+    "id" : "http://lobid.org/item/HT010726584:DE-61:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-829"
+      "id" : "http://lobid.org/organisation/DE-61"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT010726584:DE-743:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT010726584:DE-743:/about"
+      "id" : "http://lobid.org/item/HT010726584:DE-743:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT010726584",
+    "id" : "http://lobid.org/item/HT010726584:DE-743:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-743"
+      "id" : "http://lobid.org/organisation/DE-743"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT010726584:DE-836:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT010726584:DE-836:/about"
+      "id" : "http://lobid.org/item/HT010726584:DE-464:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT010726584",
+    "id" : "http://lobid.org/item/HT010726584:DE-464:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-836"
+      "id" : "http://lobid.org/organisation/DE-464"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT010726584:DE-832:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT010726584:DE-832:/about"
+      "id" : "http://lobid.org/item/HT010726584:DE-386:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT010726584",
+    "id" : "http://lobid.org/item/HT010726584:DE-386:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-832"
+      "id" : "http://lobid.org/organisation/DE-386"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT010726584:DE-1393:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT010726584:DE-1393:/about"
+      "id" : "http://lobid.org/item/HT010726584:DE-832:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT010726584",
+    "id" : "http://lobid.org/item/HT010726584:DE-832:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-1393"
+      "id" : "http://lobid.org/organisation/DE-832"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT010726584:DE-Bi10:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT010726584:DE-Bi10:/about"
+      "id" : "http://lobid.org/item/HT010726584:DE-1393:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT010726584",
+    "id" : "http://lobid.org/item/HT010726584:DE-1393:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Bi10"
+      "id" : "http://lobid.org/organisation/DE-1393"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT010726584:DE-38:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT010726584:DE-38:/about"
+      "id" : "http://lobid.org/item/HT010726584:DE-82:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT010726584",
+    "id" : "http://lobid.org/item/HT010726584:DE-82:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-38"
+      "id" : "http://lobid.org/organisation/DE-82"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT010726584:DE-467:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT010726584:DE-467:/about"
+      "id" : "http://lobid.org/item/HT010726584:DE-6:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT010726584",
+    "id" : "http://lobid.org/item/HT010726584:DE-6:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-467"
+      "id" : "http://lobid.org/organisation/DE-6"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT010726584:DE-A96:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT010726584:DE-A96:/about"
+      "id" : "http://lobid.org/item/HT010726584:DE-A96:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT010726584",
+    "id" : "http://lobid.org/item/HT010726584:DE-A96:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-A96"
+      "id" : "http://lobid.org/organisation/DE-A96"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT010726584:DE-464:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT010726584:DE-464:/about"
+      "id" : "http://lobid.org/item/HT010726584:DE-107:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT010726584",
+    "id" : "http://lobid.org/item/HT010726584:DE-107:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-464"
+      "id" : "http://lobid.org/organisation/DE-107"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   } ],
   "fulltextOnline" : [ {
-    "@id" : "http://www.bibliothek.uni-regensburg.de/ezeit/?1472746"
+    "id" : "http://www.bibliothek.uni-regensburg.de/ezeit/?1472746"
   }, {
-    "@id" : "http://search.ebscohost.com/"
+    "id" : "http://search.ebscohost.com/"
   } ],
   "hasVersion" : [ {
-    "@id" : "http://www.bibliothek.uni-regensburg.de/ezeit/?1472746"
+    "id" : "http://www.bibliothek.uni-regensburg.de/ezeit/?1472746"
   }, {
-    "@id" : "http://search.ebscohost.com/"
+    "id" : "http://search.ebscohost.com/"
   } ],
   "hbzId" : [ "HT010726584" ],
+  "id" : "http://lobid.org/resource/HT010726584",
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT010726584"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT010726584"
   } ],
   "issn" : [ "10897674" ],
   "issued" : [ "1994 - " ],
   "language" : [ {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/eng"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/eng"
   } ],
   "medium" : [ {
-    "@id" : "http://rdvocab.info/termList/RDACarrierType/1018"
+    "id" : "http://rdvocab.info/termList/RDACarrierType/1018"
   }, {
-    "@id" : "http://rdvocab.info/termList/RDACarrierType/1010"
+    "id" : "http://rdvocab.info/termList/RDACarrierType/1010"
   } ],
   "otherTitleInformation" : [ "devoted to original contributions to and reviews of the physics of plasmas, including magnetofluid mechanics, kinetic theory and statistical mechanics of fully and partially ionized gases" ],
   "placeOfPublication" : [ "[S.l.]" ],
   "publicationStatement" : [ "[S.l.]; American Institute of Physics; 1994" ],
   "publisher" : [ "American Institute of Physics" ],
   "sameAs" : [ {
-    "@id" : "http://ld.zdb-services.de/resource/1472746-8"
+    "id" : "http://ld.zdb-services.de/resource/1472746-8"
   }, {
-    "@id" : "http://lobid.org/resource/ZDB1472746-8",
     "describedby" : [ {
-      "@id" : "http://lobid.org/resource/ZDB1472746-8/about"
+      "id" : "http://lobid.org/resource/ZDB1472746-8/about"
     } ],
+    "id" : "http://lobid.org/resource/ZDB1472746-8",
     "sameAs" : "http://lobid.org/resource/HT010726584"
   } ],
   "shortTitle" : [ "PHPAEN" ],
   "statementOfResponsibility" : [ "publ. by the American Institute of Physics" ],
   "subject" : [ {
-    "@id" : "http://dewey.info/class/530/"
+    "id" : "http://dewey.info/class/530/"
   }, {
-    "@id" : "http://d-nb.info/gnd/4067488-5",
+    "id" : "http://d-nb.info/gnd/4067488-5",
     "preferredName" : "Zeitschrift",
     "preferredNameForTheSubjectHeading" : "Zeitschrift"
   }, {
-    "@id" : "http://d-nb.info/gnd/4046259-6",
+    "id" : "http://d-nb.info/gnd/4046259-6",
     "preferredName" : "Plasmaphysik",
     "preferredNameForTheSubjectHeading" : "Plasmaphysik"
   }, {
-    "@id" : "http://d-nb.info/gnd/4511937-5",
+    "id" : "http://d-nb.info/gnd/4511937-5",
     "preferredName" : "Online-Publikation",
     "preferredNameForTheSubjectHeading" : "Online-Publikation"
   } ],
@@ -461,10 +395,6 @@
   "subjectLabel" : [ "Online-Ressource", "On-line-Dokument", "Netzpublikation", "On-line-Publikation", "Online-Dokument", "On-line-Datenbank (Formschlagwort)", "Zeitschriften", "Computerdatei im Fernzugriff (Formschlagwort)", "Online-Datenbank (Formschlagwort)", "Periodikum" ],
   "subjectOrder" : [ "http://d-nb.info/gnd/4046259-6, http://d-nb.info/gnd/4067488-5, http://d-nb.info/gnd/4511937-5" ],
   "title" : [ "Physics of plasmas" ],
-  "type" : [ {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  }, {
-    "@id" : "http://purl.org/ontology/bibo/Journal"
-  } ],
+  "type" : [ "http://purl.org/ontology/bibo/Journal", "http://purl.org/dc/terms/BibliographicResource" ],
   "zdbId" : [ "1472746-8" ]
 }

--- a/src/test/resources/output/json/01223/HT012237361.json
+++ b/src/test/resources/output/json/01223/HT012237361.json
@@ -1,61 +1,55 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/HT012237361",
   "contributingCorporateBodyLabel" : [ "Statistisches Landesamt Rheinland-Pfalz", "Rheinland-Pfalz", "Statistisches Landesamt" ],
   "contributorOrder" : [ "http://d-nb.info/gnd/36467-8" ],
   "creator" : [ {
-    "@id" : "http://d-nb.info/gnd/36467-8",
+    "id" : "http://d-nb.info/gnd/36467-8",
     "preferredName" : "Rheinland-Pfalz",
     "preferredNameForTheCorporateBody" : "Rheinland-Pfalz"
   } ],
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/HT012237361/about",
     "dateCreated" : "19991120",
-    "dateModified" : "20080109"
+    "dateModified" : "20080109",
+    "id" : "http://lobid.org/resource/HT012237361/about"
   } ],
   "exemplar" : [ {
-    "@id" : "http://lobid.org/item/HT012237361:DE-107:Per.%205157",
     "callNumber" : "Per. 5157",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT012237361:DE-107:Per.%205157/about"
+      "id" : "http://lobid.org/item/HT012237361:DE-107:Per.%205157/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT012237361",
+    "id" : "http://lobid.org/item/HT012237361:DE-107:Per.%205157",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-107"
+      "id" : "http://lobid.org/organisation/DE-107"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   } ],
   "hbzId" : [ "HT012237361" ],
+  "id" : "http://lobid.org/resource/HT012237361",
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT012237361"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT012237361"
   } ],
   "issued" : [ "1975 - 1975" ],
   "language" : [ {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
   } ],
   "medium" : [ {
-    "@id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
+    "id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
   } ],
   "otherTitleInformation" : [ "Statistische Berichte des Statistischen Landesamtes Rheinland-Pfalz" ],
   "placeOfPublication" : [ "Bad Ems" ],
   "publicationStatement" : [ "Bad Ems; Statist. Landesamt; 1975" ],
   "publisher" : [ "Statist. Landesamt" ],
   "sameAs" : [ {
-    "@id" : "http://lobid.org/resource/ZDB590016-5",
     "describedby" : [ {
-      "@id" : "http://lobid.org/resource/ZDB590016-5/about"
+      "id" : "http://lobid.org/resource/ZDB590016-5/about"
     } ],
+    "id" : "http://lobid.org/resource/ZDB590016-5",
     "sameAs" : "http://lobid.org/resource/HT012237361"
   }, {
-    "@id" : "http://ld.zdb-services.de/resource/590016-5"
+    "id" : "http://ld.zdb-services.de/resource/590016-5"
   } ],
   "title" : [ "Statistische Berichte des Statistischen Landesamtes Rheinland-Pfalz / L / 4 / 6" ],
-  "type" : [ {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  }, {
-    "@id" : "http://purl.org/ontology/bibo/Journal"
-  } ],
+  "type" : [ "http://purl.org/ontology/bibo/Journal", "http://purl.org/dc/terms/BibliographicResource" ],
   "zdbId" : [ "590016-5" ]
 }

--- a/src/test/resources/output/json/01289/HT012895751.json
+++ b/src/test/resources/output/json/01289/HT012895751.json
@@ -1,55 +1,53 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/HT012895751",
   "contributorOrder" : [ "http://d-nb.info/gnd/2037247-4" ],
   "creator" : [ {
-    "@id" : "http://d-nb.info/gnd/2037247-4",
+    "id" : "http://d-nb.info/gnd/2037247-4",
     "preferredName" : "Main-Kinzig-Kreis"
   } ],
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/HT012895751/about",
     "dateCreated" : "20010111",
-    "dateModified" : "20010312"
+    "dateModified" : "20010312",
+    "id" : "http://lobid.org/resource/HT012895751/about"
   } ],
   "exemplar" : [ {
-    "@id" : "http://lobid.org/item/HT012895751:DE-929:C2001A%2F13",
     "callNumber" : "C2001A/13",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT012895751:DE-929:C2001A%2F13/about"
+      "id" : "http://lobid.org/item/HT012895751:DE-929:C2001A%2F13/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT012895751",
+    "id" : "http://lobid.org/item/HT012895751:DE-929:C2001A%2F13",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-929"
+      "id" : "http://lobid.org/organisation/DE-929"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   } ],
   "extent" : [ "76 S. : zahlr. Ill." ],
   "hbzId" : [ "HT012895751" ],
+  "id" : "http://lobid.org/resource/HT012895751",
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT012895751"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT012895751"
   } ],
   "issued" : [ "2000" ],
   "language" : [ {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
   } ],
   "medium" : [ {
-    "@id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
+    "id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
   } ],
   "otherTitleInformation" : [ "Informationen für Bürger, Neubürger & Gäste" ],
   "placeOfPublication" : [ "Bad Kreuznach" ],
   "publicationStatement" : [ "Bad Kreuznach; FORM-Medien-Verl.-Ges.; 2000" ],
   "publisher" : [ "FORM-Medien-Verl.-Ges." ],
   "sameAs" : [ {
-    "@id" : "http://hub.culturegraph.org/resource/HBZ-HT012895751"
+    "id" : "http://hub.culturegraph.org/resource/HBZ-HT012895751"
   } ],
   "subject" : [ {
-    "@id" : "http://d-nb.info/gnd/4037117-7",
+    "id" : "http://d-nb.info/gnd/4037117-7",
     "preferredName" : "Main-Kinzig-Kreis",
     "preferredNameForThePlaceOrGeographicName" : "Main-Kinzig-Kreis"
   }, {
-    "@id" : "http://d-nb.info/gnd/4127794-6",
+    "id" : "http://d-nb.info/gnd/4127794-6",
     "preferredName" : "Heimatkunde",
     "preferredNameForTheSubjectHeading" : "Heimatkunde"
   } ],
@@ -57,9 +55,5 @@
   "subjectLabel" : [ "Heimatgeschichte", "Heimatforschung" ],
   "subjectOrder" : [ "http://d-nb.info/gnd/4037117-7, http://d-nb.info/gnd/4127794-6" ],
   "title" : [ "Mainz-Kinzig-Kreis" ],
-  "type" : [ {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  }, {
-    "@id" : "http://purl.org/ontology/bibo/Book"
-  } ]
+  "type" : [ "http://purl.org/ontology/bibo/Book", "http://purl.org/dc/terms/BibliographicResource" ]
 }

--- a/src/test/resources/output/json/01292/HT012926727.json
+++ b/src/test/resources/output/json/01292/HT012926727.json
@@ -1,527 +1,453 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/HT012926727",
   "contributorLabel" : [ "Müller, Leonhard", "Müller, L." ],
   "contributorOrder" : [ "http://d-nb.info/gnd/1031919368" ],
   "creator" : [ {
-    "@id" : "http://d-nb.info/gnd/1031919368",
+    "id" : "http://d-nb.info/gnd/1031919368",
     "preferredName" : "Müller, Leonhard",
     "preferredNameForThePerson" : "Müller, Leonhard"
   } ],
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/HT012926727/about",
     "dateCreated" : "20010220",
-    "dateModified" : "20130305"
+    "dateModified" : "20130305",
+    "id" : "http://lobid.org/resource/HT012926727/about"
   } ],
   "edition" : [ "2. Aufl." ],
   "exemplar" : [ {
-    "@id" : "http://lobid.org/item/HT012926727:DE-464:XYG1451(2)%2B1_d",
-    "callNumber" : "XYG1451(2)+1_d",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT012926727:DE-464:XYG1451(2)%2B1_d/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT012926727",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-464"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT012926727:DE-1010:01PUM23(2)",
-    "callNumber" : "01PUM23(2)",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT012926727:DE-1010:01PUM23(2)/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT012926727",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-1010"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT012926727:DE-829:XYG%20M%C3%BCll",
-    "callNumber" : "XYG Müll",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT012926727:DE-829:XYG%20M%C3%BCll/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT012926727",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-829"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT012926727:DE-Bi10:XYF%20Muel",
-    "callNumber" : "XYF Muel",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT012926727:DE-Bi10:XYF%20Muel/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT012926727",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Bi10"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT012926727:DE-294:WQB20673:2",
-    "callNumber" : "WQB20673:2",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT012926727:DE-294:WQB20673:2/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT012926727",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-294"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT012926727:DE-836:PUM%2016(2)",
-    "callNumber" : "PUM 16(2)",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT012926727:DE-836:PUM%2016(2)/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT012926727",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-836"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT012926727:DE-1042:etech%20A%20002%202.%20Aufl.",
-    "callNumber" : "etech A 002 2. Aufl.",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT012926727:DE-1042:etech%20A%20002%202.%20Aufl./about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT012926727",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-1042"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT012926727:DE-1393:00%2FXYG3(2)%2B4",
-    "callNumber" : "00/XYG3(2)+4",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT012926727:DE-1393:00%2FXYG3(2)%2B4/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT012926727",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-1393"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT012926727:DE-Hag4-4:81PUM5023(2)%2B1",
     "callNumber" : "81PUM5023(2)+1",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT012926727:DE-Hag4-4:81PUM5023(2)%2B1/about"
+      "id" : "http://lobid.org/item/HT012926727:DE-Hag4-4:81PUM5023(2)%2B1/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT012926727",
+    "id" : "http://lobid.org/item/HT012926727:DE-Hag4-4:81PUM5023(2)%2B1",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Hag4-4"
+      "id" : "http://lobid.org/organisation/DE-Hag4-4"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT012926727:DE-A96:21%20ZPH%20743(2)",
-    "callNumber" : "21 ZPH 743(2)",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT012926727:DE-A96:21%20ZPH%20743(2)/about"
+      "id" : "http://lobid.org/item/HT012926727:DE-60:XYG1451(2)%2B1_d/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT012926727",
+    "id" : "http://lobid.org/item/HT012926727:DE-60:XYG1451(2)%2B1_d",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-A96"
+      "id" : "http://lobid.org/organisation/DE-60"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT012926727:DE-Hag4:E%2FZB-Wgm32%2020:2B",
-    "callNumber" : "E/ZB-Wgm32 20:2B",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT012926727:DE-Hag4:E%2FZB-Wgm32%2020:2B/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT012926727",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Hag4"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT012926727:DE-465:ZPH3644(2)",
-    "callNumber" : "ZPH3644(2)",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT012926727:DE-465:ZPH3644(2)/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT012926727",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-465"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT012926727:DE-60:XYG1451(2)%2B1_d",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT012926727:DE-60:XYG1451(2)%2B1_d/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT012926727",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-60"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT012926727:DE-Hag4:W-Wgm32%2020:2",
-    "callNumber" : "W-Wgm32 20:2",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT012926727:DE-Hag4:W-Wgm32%2020:2/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT012926727",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Hag4"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT012926727:DE-6:3H%2062052",
-    "callNumber" : "3H 62052",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT012926727:DE-6:3H%2062052/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT012926727",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-6"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT012926727:DE-6-017:G%20IV%20a%20132",
-    "callNumber" : "G IV a 132",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT012926727:DE-6-017:G%20IV%20a%20132/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT012926727",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-6-017"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT012926727:DE-61:wirq509.m946",
-    "callNumber" : "wirq509.m946",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT012926727:DE-61:wirq509.m946/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT012926727",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-61"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT012926727:DE-468:XYG1362(2)",
-    "callNumber" : "XYG1362(2)",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT012926727:DE-468:XYG1362(2)/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT012926727",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-468"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT012926727:DE-1393:00%2FXYG3(2)",
-    "callNumber" : "00/XYG3(2)",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT012926727:DE-1393:00%2FXYG3(2)/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT012926727",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-1393"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT012926727:DE-5-225:R%20278%202001%2F11",
-    "callNumber" : "R 278 2001/11",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT012926727:DE-5-225:R%20278%202001%2F11/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT012926727",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-5-225"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT012926727:DE-464:ZPO41357(2)",
-    "callNumber" : "ZPO41357(2)",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT012926727:DE-464:ZPO41357(2)/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT012926727",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-464"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT012926727:DE-61-81:jurj354.m946",
-    "callNumber" : "jurj354.m946",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT012926727:DE-61-81:jurj354.m946/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT012926727",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-61-81"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT012926727:DE-464:XYG1451(2)_d",
-    "callNumber" : "XYG1451(2)_d",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT012926727:DE-464:XYG1451(2)_d/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT012926727",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-464"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT012926727:DE-Dm13:XYG%206(2)",
-    "callNumber" : "XYG 6(2)",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT012926727:DE-Dm13:XYG%206(2)/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT012926727",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Dm13"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT012926727:DE-Hag4-4:81PUM5023(2)%2B2",
-    "callNumber" : "81PUM5023(2)+2",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT012926727:DE-Hag4-4:81PUM5023(2)%2B2/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT012926727",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Hag4-4"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT012926727:DE-294:WQB20673%2B1:2",
-    "callNumber" : "WQB20673+1:2",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT012926727:DE-294:WQB20673%2B1:2/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT012926727",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-294"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT012926727:DE-1393:00%2FXYG3(2)%2B2",
-    "callNumber" : "00/XYG3(2)+2",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT012926727:DE-1393:00%2FXYG3(2)%2B2/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT012926727",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-1393"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT012926727:DE-51:PUM%20119(2)",
-    "callNumber" : "PUM 119(2)",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT012926727:DE-51:PUM%20119(2)/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT012926727",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-51"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT012926727:DE-Hag4:E%2FZB-Wgm32%2020:2A",
     "callNumber" : "E/ZB-Wgm32 20:2A",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT012926727:DE-Hag4:E%2FZB-Wgm32%2020:2A/about"
+      "id" : "http://lobid.org/item/HT012926727:DE-Hag4:E%2FZB-Wgm32%2020:2A/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT012926727",
+    "id" : "http://lobid.org/item/HT012926727:DE-Hag4:E%2FZB-Wgm32%2020:2A",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Hag4"
+      "id" : "http://lobid.org/organisation/DE-Hag4"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT012926727:DE-Due62:11%20ZPH%2026%20(2)",
-    "callNumber" : "11 ZPH 26 (2)",
+    "callNumber" : "XYF Muel",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT012926727:DE-Due62:11%20ZPH%2026%20(2)/about"
+      "id" : "http://lobid.org/item/HT012926727:DE-Bi10:XYF%20Muel/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT012926727",
+    "id" : "http://lobid.org/item/HT012926727:DE-Bi10:XYF%20Muel",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Due62"
+      "id" : "http://lobid.org/organisation/DE-Bi10"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT012926727:DE-1393:00%2FXYG3(2)%2B3",
-    "callNumber" : "00/XYG3(2)+3",
+    "callNumber" : "XYG1451(2)+1_d",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT012926727:DE-1393:00%2FXYG3(2)%2B3/about"
+      "id" : "http://lobid.org/item/HT012926727:DE-464:XYG1451(2)%2B1_d/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT012926727",
+    "id" : "http://lobid.org/item/HT012926727:DE-464:XYG1451(2)%2B1_d",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-1393"
+      "id" : "http://lobid.org/organisation/DE-464"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT012926727:DE-38:28A2398",
-    "callNumber" : "28A2398",
+    "callNumber" : "XYG Müll",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT012926727:DE-38:28A2398/about"
+      "id" : "http://lobid.org/item/HT012926727:DE-829:XYG%20M%C3%BCll/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT012926727",
+    "id" : "http://lobid.org/item/HT012926727:DE-829:XYG%20M%C3%BCll",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-38"
+      "id" : "http://lobid.org/organisation/DE-829"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT012926727:DE-465:ZPH3644(2)%2B1",
+    "callNumber" : "W-Wgm32 20:2",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT012926727:DE-Hag4:W-Wgm32%2020:2/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT012926727",
+    "id" : "http://lobid.org/item/HT012926727:DE-Hag4:W-Wgm32%2020:2",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-Hag4"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "XYG1362(2)",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT012926727:DE-468:XYG1362(2)/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT012926727",
+    "id" : "http://lobid.org/item/HT012926727:DE-468:XYG1362(2)",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-468"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "wirq509.m946",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT012926727:DE-61:wirq509.m946/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT012926727",
+    "id" : "http://lobid.org/item/HT012926727:DE-61:wirq509.m946",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-61"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "ZPO41357(2)",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT012926727:DE-464:ZPO41357(2)/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT012926727",
+    "id" : "http://lobid.org/item/HT012926727:DE-464:ZPO41357(2)",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-464"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "G IV a 132",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT012926727:DE-6-017:G%20IV%20a%20132/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT012926727",
+    "id" : "http://lobid.org/item/HT012926727:DE-6-017:G%20IV%20a%20132",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-6-017"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "3H 62052",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT012926727:DE-6:3H%2062052/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT012926727",
+    "id" : "http://lobid.org/item/HT012926727:DE-6:3H%2062052",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-6"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "R 278 2001/11",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT012926727:DE-5-225:R%20278%202001%2F11/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT012926727",
+    "id" : "http://lobid.org/item/HT012926727:DE-5-225:R%20278%202001%2F11",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-5-225"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "00/XYG3(2)",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT012926727:DE-1393:00%2FXYG3(2)/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT012926727",
+    "id" : "http://lobid.org/item/HT012926727:DE-1393:00%2FXYG3(2)",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-1393"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
     "callNumber" : "ZPH3644(2)+1",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT012926727:DE-465:ZPH3644(2)%2B1/about"
+      "id" : "http://lobid.org/item/HT012926727:DE-465:ZPH3644(2)%2B1/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT012926727",
+    "id" : "http://lobid.org/item/HT012926727:DE-465:ZPH3644(2)%2B1",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-465"
+      "id" : "http://lobid.org/organisation/DE-465"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT012926727:DE-Due62:16%20ZPH%2026%20(2)%20%2B1",
-    "callNumber" : "16 ZPH 26 (2) +1",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT012926727:DE-Due62:16%20ZPH%2026%20(2)%20%2B1/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT012926727",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Due62"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT012926727:DE-468:XYG1362(2)%2B1",
     "callNumber" : "XYG1362(2)+1",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT012926727:DE-468:XYG1362(2)%2B1/about"
+      "id" : "http://lobid.org/item/HT012926727:DE-468:XYG1362(2)%2B1/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT012926727",
+    "id" : "http://lobid.org/item/HT012926727:DE-468:XYG1362(2)%2B1",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-468"
+      "id" : "http://lobid.org/organisation/DE-468"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT012926727:DE-Kob7:AR%2FG%202003%206306(2)",
+    "callNumber" : "XYG1451(2)_d",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT012926727:DE-464:XYG1451(2)_d/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT012926727",
+    "id" : "http://lobid.org/item/HT012926727:DE-464:XYG1451(2)_d",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-464"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "28A2398",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT012926727:DE-38:28A2398/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT012926727",
+    "id" : "http://lobid.org/item/HT012926727:DE-38:28A2398",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-38"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "ZPH3644(2)",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT012926727:DE-465:ZPH3644(2)/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT012926727",
+    "id" : "http://lobid.org/item/HT012926727:DE-465:ZPH3644(2)",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-465"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "XYG 6(2)",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT012926727:DE-Dm13:XYG%206(2)/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT012926727",
+    "id" : "http://lobid.org/item/HT012926727:DE-Dm13:XYG%206(2)",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-Dm13"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "81PUM5023(2)+2",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT012926727:DE-Hag4-4:81PUM5023(2)%2B2/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT012926727",
+    "id" : "http://lobid.org/item/HT012926727:DE-Hag4-4:81PUM5023(2)%2B2",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-Hag4-4"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "jurj354.m946",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT012926727:DE-61-81:jurj354.m946/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT012926727",
+    "id" : "http://lobid.org/item/HT012926727:DE-61-81:jurj354.m946",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-61-81"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "etech A 002 2. Aufl.",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT012926727:DE-1042:etech%20A%20002%202.%20Aufl./about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT012926727",
+    "id" : "http://lobid.org/item/HT012926727:DE-1042:etech%20A%20002%202.%20Aufl.",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-1042"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "PUM 16(2)",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT012926727:DE-836:PUM%2016(2)/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT012926727",
+    "id" : "http://lobid.org/item/HT012926727:DE-836:PUM%2016(2)",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-836"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "01PUM23(2)",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT012926727:DE-1010:01PUM23(2)/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT012926727",
+    "id" : "http://lobid.org/item/HT012926727:DE-1010:01PUM23(2)",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-1010"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "00/XYG3(2)+2",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT012926727:DE-1393:00%2FXYG3(2)%2B2/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT012926727",
+    "id" : "http://lobid.org/item/HT012926727:DE-1393:00%2FXYG3(2)%2B2",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-1393"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "WQB20673+1:2",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT012926727:DE-294:WQB20673%2B1:2/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT012926727",
+    "id" : "http://lobid.org/item/HT012926727:DE-294:WQB20673%2B1:2",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-294"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "21 ZPH 743(2)",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT012926727:DE-A96:21%20ZPH%20743(2)/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT012926727",
+    "id" : "http://lobid.org/item/HT012926727:DE-A96:21%20ZPH%20743(2)",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-A96"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "00/XYG3(2)+3",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT012926727:DE-1393:00%2FXYG3(2)%2B3/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT012926727",
+    "id" : "http://lobid.org/item/HT012926727:DE-1393:00%2FXYG3(2)%2B3",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-1393"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "00/XYG3(2)+4",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT012926727:DE-1393:00%2FXYG3(2)%2B4/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT012926727",
+    "id" : "http://lobid.org/item/HT012926727:DE-1393:00%2FXYG3(2)%2B4",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-1393"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "E/ZB-Wgm32 20:2B",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT012926727:DE-Hag4:E%2FZB-Wgm32%2020:2B/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT012926727",
+    "id" : "http://lobid.org/item/HT012926727:DE-Hag4:E%2FZB-Wgm32%2020:2B",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-Hag4"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
     "callNumber" : "AR/G 2003 6306(2)",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT012926727:DE-Kob7:AR%2FG%202003%206306(2)/about"
+      "id" : "http://lobid.org/item/HT012926727:DE-Kob7:AR%2FG%202003%206306(2)/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT012926727",
+    "id" : "http://lobid.org/item/HT012926727:DE-Kob7:AR%2FG%202003%206306(2)",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Kob7"
+      "id" : "http://lobid.org/organisation/DE-Kob7"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT012926727:DE-Hag4-4:81PUM5023(2)",
     "callNumber" : "81PUM5023(2)",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT012926727:DE-Hag4-4:81PUM5023(2)/about"
+      "id" : "http://lobid.org/item/HT012926727:DE-Hag4-4:81PUM5023(2)/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT012926727",
+    "id" : "http://lobid.org/item/HT012926727:DE-Hag4-4:81PUM5023(2)",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Hag4-4"
+      "id" : "http://lobid.org/organisation/DE-Hag4-4"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "16 ZPH 26 (2) +1",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT012926727:DE-Due62:16%20ZPH%2026%20(2)%20%2B1/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT012926727",
+    "id" : "http://lobid.org/item/HT012926727:DE-Due62:16%20ZPH%2026%20(2)%20%2B1",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-Due62"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "PUM 119(2)",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT012926727:DE-51:PUM%20119(2)/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT012926727",
+    "id" : "http://lobid.org/item/HT012926727:DE-51:PUM%20119(2)",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-51"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "WQB20673:2",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT012926727:DE-294:WQB20673:2/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT012926727",
+    "id" : "http://lobid.org/item/HT012926727:DE-294:WQB20673:2",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-294"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "11 ZPH 26 (2)",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT012926727:DE-Due62:11%20ZPH%2026%20(2)/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT012926727",
+    "id" : "http://lobid.org/item/HT012926727:DE-Due62:11%20ZPH%2026%20(2)",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-Due62"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   } ],
   "extent" : [ "XIV, 514 S. : graph. Darst., Kt." ],
   "hbzId" : [ "HT012926727" ],
+  "id" : "http://lobid.org/resource/HT012926727",
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT012926727"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT012926727"
   } ],
   "isbn" : [ "9783540676379", "3540676376", "9783642631948" ],
   "issued" : [ "2001" ],
   "language" : [ {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
   } ],
   "medium" : [ {
-    "@id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
+    "id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
   } ],
   "otherTitleInformation" : [ "technische, wirtschaftliche und rechtliche Grundlagen" ],
   "placeOfPublication" : [ "Berlin [u.a.]" ],
   "publicationStatement" : [ "Berlin [u.a.]; Springer; 2001" ],
   "publisher" : [ "Springer" ],
   "sameAs" : [ {
-    "@id" : "http://hub.culturegraph.org/resource/HBZ-HT012926727"
+    "id" : "http://hub.culturegraph.org/resource/HBZ-HT012926727"
   } ],
   "statementOfResponsibility" : [ "Leonhard Müller" ],
   "subject" : [ {
-    "@id" : "http://d-nb.info/gnd/4011882-4",
+    "id" : "http://d-nb.info/gnd/4011882-4",
     "preferredName" : "Deutschland",
     "preferredNameForThePlaceOrGeographicName" : "Deutschland"
   }, {
-    "@id" : "http://d-nb.info/gnd/4014228-0",
+    "id" : "http://d-nb.info/gnd/4014228-0",
     "preferredName" : "Elektrizitätswirtschaft",
     "preferredNameForTheSubjectHeading" : "Elektrizitätswirtschaft"
   } ],
@@ -529,12 +455,8 @@
   "subjectLabel" : [ "Deutsche Länder", "Stromwirtschaft", "Deutschland (Gebiet unter Alliierter Besatzung)", "Norddeutscher Bund", "Allemagne (Deutschland)", "Federal Republic of Germany (Deutschland)", "Heiliges Römisches Reich", "République Fédérale d'Allemagne (Deutschland)", "Germanija", "Germany (Deutschland)", "Rheinbund", "Deutschland (Bundesrepublik, 1990-)", "Elektrischer Strom / Energiewirtschaft", "Federativnaja Respublika Germanija", "Republic of Germany (Deutschland)", "Repubblica Federale di Germania (Deutschland)", "Deyizhi-Lianbang-Gongheguo", "Niemcy", "Deutsches Reich", "Bundesrepublik Deutschland (1990-)", "BRD (1990-)", "BRD", "Elektrizität / Wirtschaft", "Deutscher Bund", "FRG", "Ǧumhūrīyat Almāniyā al-Ittiḥādīya", "Elektrizität / Energiewirtschaft" ],
   "subjectOrder" : [ "http://d-nb.info/gnd/4011882-4, http://d-nb.info/gnd/4014228-0" ],
   "tableOfContents" : [ {
-    "@id" : "http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=1533597&custom_att_2=simple_viewer"
+    "id" : "http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=1533597&custom_att_2=simple_viewer"
   } ],
   "title" : [ "Handbuch der Elektrizitätswirtschaft" ],
-  "type" : [ {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  }, {
-    "@id" : "http://purl.org/ontology/bibo/Book"
-  } ]
+  "type" : [ "http://purl.org/ontology/bibo/Book", "http://purl.org/dc/terms/BibliographicResource" ]
 }

--- a/src/test/resources/output/json/01307/HT013077595.json
+++ b/src/test/resources/output/json/01307/HT013077595.json
@@ -1,16 +1,15 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/HT013077595",
   "collectedBy" : [ {
-    "@id" : "http://lobid.org/resource/NWBib"
+    "id" : "http://lobid.org/resource/NWBib"
   } ],
   "contributingCorporateBodyLabel" : [ "Kreisheimatverein" ],
   "contributor" : [ {
-    "@id" : "http://d-nb.info/gnd/128755-2",
+    "id" : "http://d-nb.info/gnd/128755-2",
     "preferredName" : "Kreisheimatverein <Coesfeld>",
     "preferredNameForTheCorporateBody" : "Kreisheimatverein <Coesfeld>"
   }, {
-    "@id" : "http://d-nb.info/gnd/11079267X",
+    "id" : "http://d-nb.info/gnd/11079267X",
     "preferredName" : "Balke, Kirsten",
     "preferredNameForThePerson" : "Balke, Kirsten"
   } ],
@@ -18,91 +17,86 @@
   "contributorOrder" : [ "http://d-nb.info/gnd/11079267X | http://d-nb.info/gnd/109490312 | http://d-nb.info/gnd/128755-2" ],
   "coverage" : [ "Coesfeld <Kreis>", "Coesfeld" ],
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/HT013077595/about",
     "dateCreated" : "20010705",
-    "dateModified" : "20011113"
+    "dateModified" : "20011113",
+    "id" : "http://lobid.org/resource/HT013077595/about"
   } ],
   "exemplar" : [ {
-    "@id" : "http://lobid.org/item/HT013077595:DE-6-290:Y%20401%20-%2036",
     "callNumber" : "Y 401 - 36",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT013077595:DE-6-290:Y%20401%20-%2036/about"
+      "id" : "http://lobid.org/item/HT013077595:DE-6-290:Y%20401%20-%2036/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT013077595",
+    "id" : "http://lobid.org/item/HT013077595:DE-6-290:Y%20401%20-%2036",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-6-290"
+      "id" : "http://lobid.org/organisation/DE-6-290"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT013077595:DE-6:AA%2012514",
-    "callNumber" : "AA 12514",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT013077595:DE-6:AA%2012514/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT013077595",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-6"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT013077595:DE-6:2J%201468",
     "callNumber" : "2J 1468",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT013077595:DE-6:2J%201468/about"
+      "id" : "http://lobid.org/item/HT013077595:DE-6:2J%201468/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT013077595",
+    "id" : "http://lobid.org/item/HT013077595:DE-6:2J%201468",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-6"
+      "id" : "http://lobid.org/organisation/DE-6"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "AA 12514",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT013077595:DE-6:AA%2012514/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT013077595",
+    "id" : "http://lobid.org/item/HT013077595:DE-6:AA%2012514",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-6"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   } ],
   "extent" : [ "VII, 119 S. : Ill., graph. Darst., Kt." ],
   "hbzId" : [ "HT013077595" ],
+  "id" : "http://lobid.org/resource/HT013077595",
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT013077595"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT013077595"
   } ],
   "issued" : [ "2000" ],
   "language" : [ {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
   } ],
   "medium" : [ {
-    "@id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
+    "id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
   } ],
   "nwbibspatial" : [ {
-    "@id" : "http://purl.org/lobid/nwbib-spatial#n97"
+    "id" : "http://purl.org/lobid/nwbib-spatial#n97"
   } ],
   "nwbibsubject" : [ {
-    "@id" : "http://purl.org/lobid/nwbib#s240000"
+    "id" : "http://purl.org/lobid/nwbib#s240000"
   }, {
-    "@id" : "http://purl.org/lobid/nwbib#s784080"
+    "id" : "http://purl.org/lobid/nwbib#s784080"
   } ],
   "otherTitleInformation" : [ "Kirsten Balke. [Hrsg.: Kreisheimatverein Coesfeld e.V. Red.: Hans-Peter Boer ...]" ],
   "placeOfPublication" : [ "Coesfeld" ],
   "publicationStatement" : [ "Coesfeld; 2000" ],
   "redaktor" : [ {
-    "@id" : "http://d-nb.info/gnd/109490312",
+    "id" : "http://d-nb.info/gnd/109490312",
     "preferredName" : "Boer, Hans-Peter",
     "preferredNameForThePerson" : "Boer, Hans-Peter"
   } ],
   "sameAs" : [ {
-    "@id" : "http://hub.culturegraph.org/resource/HBZ-HT013077595"
+    "id" : "http://hub.culturegraph.org/resource/HBZ-HT013077595"
   } ],
   "subject" : [ {
-    "@id" : "http://d-nb.info/gnd/4010355-9",
+    "id" : "http://d-nb.info/gnd/4010355-9",
     "preferredName" : "Coesfeld",
     "preferredNameForThePlaceOrGeographicName" : "Coesfeld"
   }, {
-    "@id" : "http://d-nb.info/gnd/4010356-0",
+    "id" : "http://d-nb.info/gnd/4010356-0",
     "preferredName" : "Kreis Coesfeld",
     "preferredNameForThePlaceOrGeographicName" : "Kreis Coesfeld"
   }, {
-    "@id" : "http://d-nb.info/gnd/4024116-6",
+    "id" : "http://d-nb.info/gnd/4024116-6",
     "preferredName" : "Heimatkundeunterricht",
     "preferredNameForTheSubjectHeading" : "Heimatkundeunterricht"
   } ],
@@ -110,9 +104,5 @@
   "subjectLabel" : [ "Heimatkunde (Unterricht)", "Heimatkundedidaktik", "Kreistag (Kreis Coesfeld)", "Stadt Coesfeld", "Hauptamt (Kreis Coesfeld)", "Kreis Coesfeld. Kreistag", "Coesfeld. Hauptamt", "Coesfeld (Kreis)", "Kosfel'd", "Kreis Coesfeld. Hauptamt", "Coesfeld. Stadtdirektor", "Stadtdirektor (Coesfeld)", "Kreis Coesfeld. Kreisverwaltung", "Heimatkunde / Didaktik", "Coesfeld. Pressestelle", "Oberkreisdirektor (Kreis Coesfeld)", "Landrat (Kreis Coesfeld)", "Hauptamt (Coesfeld)", "Kreis Coesfeld. Oberkreisdirektor", "Landkreis Coesfeld", "Kreis Coesfeld. Landrat", "Kreisverwaltung (Kreis Coesfeld)", "Pressestelle (Coesfeld)" ],
   "subjectOrder" : [ "http://d-nb.info/gnd/4010355-9, http://d-nb.info/gnd/4024116-6, Lehrmittel", "http://d-nb.info/gnd/4010356-0, http://d-nb.info/gnd/4024116-6, Lehrmittel" ],
   "title" : [ "Geschichte hier" ],
-  "type" : [ {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  }, {
-    "@id" : "http://purl.org/ontology/bibo/Book"
-  } ]
+  "type" : [ "http://purl.org/ontology/bibo/Book", "http://purl.org/dc/terms/BibliographicResource" ]
 }

--- a/src/test/resources/output/json/01330/HT013304490.json
+++ b/src/test/resources/output/json/01330/HT013304490.json
@@ -1,65 +1,59 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/HT013304490",
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/HT013304490/about",
     "dateCreated" : "20020301",
-    "dateModified" : "20130724"
+    "dateModified" : "20130724",
+    "id" : "http://lobid.org/resource/HT013304490/about"
   } ],
   "exemplar" : [ {
-    "@id" : "http://lobid.org/item/HT013304490:DE-829:%3C%3C01%3E%3E%2034%20Z%2041",
-    "callNumber" : "<<01>> 34 Z 41",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT013304490:DE-829:%3C%3C01%3E%3E%2034%20Z%2041/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT013304490",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-829"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT013304490:DE-Kn3:Zd%20Decide",
     "callNumber" : "Zd Decide",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT013304490:DE-Kn3:Zd%20Decide/about"
+      "id" : "http://lobid.org/item/HT013304490:DE-Kn3:Zd%20Decide/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT013304490",
+    "id" : "http://lobid.org/item/HT013304490:DE-Kn3:Zd%20Decide",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Kn3"
+      "id" : "http://lobid.org/organisation/DE-Kn3"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT013304490:DE-Tr5:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT013304490:DE-Tr5:/about"
+      "id" : "http://lobid.org/item/HT013304490:DE-Tr5:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT013304490",
+    "id" : "http://lobid.org/item/HT013304490:DE-Tr5:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Tr5"
+      "id" : "http://lobid.org/organisation/DE-Tr5"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "<<01>> 34 Z 41",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT013304490:DE-829:%3C%3C01%3E%3E%2034%20Z%2041/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT013304490",
+    "id" : "http://lobid.org/item/HT013304490:DE-829:%3C%3C01%3E%3E%2034%20Z%2041",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-829"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   } ],
   "frequency" : [ "Periodizität: vierteljährl." ],
   "hasSupplement" : [ {
-    "@id" : "http://lobid.org/resource/HT013304885"
+    "id" : "http://lobid.org/resource/HT013304885"
   } ],
   "hbzId" : [ "HT013304490" ],
+  "id" : "http://lobid.org/resource/HT013304490",
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT013304490"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT013304490"
   } ],
   "issn" : [ "16187792" ],
   "issued" : [ "2002 - 2002" ],
   "language" : [ {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
   } ],
   "medium" : [ {
-    "@id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
+    "id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
   } ],
   "oclcnum" : [ "635743319" ],
   "otherTitleInformation" : [ "Magazin für Frauen, Kultur & Luxus" ],
@@ -67,43 +61,39 @@
   "publicationStatement" : [ "Ulm; Ebner; 2002" ],
   "publisher" : [ "Ebner" ],
   "sameAs" : [ {
-    "@id" : "http://worldcat.org/oclc/635743319"
+    "id" : "http://worldcat.org/oclc/635743319"
   }, {
-    "@id" : "http://lobid.org/resource/ZDB2073588-1",
     "describedby" : [ {
-      "@id" : "http://lobid.org/resource/ZDB2073588-1/about"
+      "id" : "http://lobid.org/resource/ZDB2073588-1/about"
     } ],
+    "id" : "http://lobid.org/resource/ZDB2073588-1",
     "sameAs" : "http://lobid.org/resource/HT013304490"
   }, {
-    "@id" : "http://ld.zdb-services.de/resource/2073588-1"
+    "id" : "http://ld.zdb-services.de/resource/2073588-1"
   } ],
   "subject" : [ {
-    "@id" : "http://dewey.info/class/070/"
+    "id" : "http://dewey.info/class/070/"
   }, {
-    "@id" : "http://dewey.info/class/620/"
+    "id" : "http://dewey.info/class/620/"
   }, {
-    "@id" : "http://d-nb.info/gnd/4052945-9",
+    "id" : "http://d-nb.info/gnd/4052945-9",
     "preferredName" : "Schmuck",
     "preferredNameForTheSubjectHeading" : "Schmuck"
   }, {
-    "@id" : "http://d-nb.info/gnd/4067488-5",
+    "id" : "http://d-nb.info/gnd/4067488-5",
     "preferredName" : "Zeitschrift",
     "preferredNameForTheSubjectHeading" : "Zeitschrift"
   }, {
-    "@id" : "http://dewey.info/class/050/"
+    "id" : "http://dewey.info/class/050/"
   }, {
-    "@id" : "http://dewey.info/class/790/"
+    "id" : "http://dewey.info/class/790/"
   }, {
-    "@id" : "http://dewey.info/class/791/"
+    "id" : "http://dewey.info/class/791/"
   } ],
   "subjectChain" : [ "Schmuck | Zeitschrift" ],
   "subjectLabel" : [ "Juwelierschmuck", "Zeitschriften", "Periodikum", "Schmuckware", "Juwelen", "Juwelenschmuck" ],
   "subjectOrder" : [ "http://d-nb.info/gnd/4052945-9, http://d-nb.info/gnd/4067488-5" ],
   "title" : [ "Décidé" ],
-  "type" : [ {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  }, {
-    "@id" : "http://purl.org/ontology/bibo/Journal"
-  } ],
+  "type" : [ "http://purl.org/ontology/bibo/Journal", "http://purl.org/dc/terms/BibliographicResource" ],
   "zdbId" : [ "2073588-1" ]
 }

--- a/src/test/resources/output/json/01357/HT013577568.json
+++ b/src/test/resources/output/json/01357/HT013577568.json
@@ -1,68 +1,68 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/HT013577568",
   "bibliographicCitation" : [ "Kontinuität und Diskontinuität / hrsg. von Thomas Grünewald ... - Berlin [u.a.], 2003. - (Reallexikon der germanischen Altertumskunde : Ergänzungsbände ; 35). - S. [266]-344 : Ill., Kt." ],
   "collectedBy" : [ {
-    "@id" : "http://lobid.org/resource/NWBib"
+    "id" : "http://lobid.org/resource/NWBib"
   } ],
   "containedIn" : [ {
-    "@id" : "http://lobid.org/resource/HT013538692"
+    "id" : "http://lobid.org/resource/HT013538692"
   } ],
   "contributorLabel" : [ "Heinrichs, Johannes" ],
   "contributorOrder" : [ "http://d-nb.info/gnd/108092704" ],
   "creator" : [ {
-    "@id" : "http://d-nb.info/gnd/108092704",
+    "id" : "http://d-nb.info/gnd/108092704",
     "preferredName" : "Heinrichs, Johannes",
     "preferredNameForThePerson" : "Heinrichs, Johannes"
   } ],
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/HT013577568/about",
-    "dateCreated" : "20030212"
+    "dateCreated" : "20030212",
+    "id" : "http://lobid.org/resource/HT013577568/about"
   } ],
   "hbzId" : [ "HT013577568" ],
+  "id" : "http://lobid.org/resource/HT013577568",
   "isPartOf" : [ {
-    "@id" : "http://lobid.org/resource/HT013538692"
+    "id" : "http://lobid.org/resource/HT013538692"
   } ],
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT013577568"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT013577568"
   } ],
   "issued" : [ "2003" ],
   "language" : [ {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
   } ],
   "medium" : [ {
-    "@id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
+    "id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
   } ],
   "nwbibspatial" : [ {
-    "@id" : "http://purl.org/lobid/nwbib-spatial#n03"
+    "id" : "http://purl.org/lobid/nwbib-spatial#n03"
   } ],
   "nwbibsubject" : [ {
-    "@id" : "http://purl.org/lobid/nwbib#s226040"
+    "id" : "http://purl.org/lobid/nwbib#s226040"
   } ],
   "otherTitleInformation" : [ "Mittel- und Niederrhein ca. 70 - 71 v. Chr. anhand germanischer Münzen" ],
   "publicationStatement" : [ "2003" ],
   "sameAs" : [ {
-    "@id" : "http://hub.culturegraph.org/resource/HBZ-HT013577568"
+    "id" : "http://hub.culturegraph.org/resource/HBZ-HT013577568"
   } ],
   "statementOfResponsibility" : [ "von Johannes Heinrichs" ],
   "subject" : [ {
-    "@id" : "http://d-nb.info/gnd/4049788-4",
+    "id" : "http://d-nb.info/gnd/4049788-4",
     "preferredName" : "Rheinland",
     "preferredNameForThePlaceOrGeographicName" : "Rheinland"
   }, {
-    "@id" : "http://d-nb.info/gnd/4126078-8",
+    "id" : "http://d-nb.info/gnd/4126078-8",
     "preferredName" : "Münzfund",
     "preferredNameForTheSubjectHeading" : "Münzfund"
   }, {
-    "@id" : "http://d-nb.info/gnd/4020378-5",
+    "id" : "http://d-nb.info/gnd/4020378-5",
     "preferredName" : "Germanen",
     "preferredNameForTheSubjectHeading" : "Germanen"
   }, {
-    "@id" : "http://d-nb.info/gnd/4040629-5",
+    "id" : "http://d-nb.info/gnd/4040629-5",
     "preferredName" : "Münze",
     "preferredNameForTheSubjectHeading" : "Münze"
   }, {
-    "@id" : "http://d-nb.info/gnd/4076769-3",
+    "id" : "http://d-nb.info/gnd/4076769-3",
     "preferredName" : "Römerzeit",
     "preferredNameForTheSubjectHeading" : "Römerzeit"
   } ],
@@ -70,9 +70,5 @@
   "subjectLabel" : [ "Metallgeld", "Fundmünze", "Münzschatz", "Römische Zeit", "Germanische Völker", "Rheinlande (im engeren Sinn)", "Münzen" ],
   "subjectOrder" : [ "http://d-nb.info/gnd/4049788-4, http://d-nb.info/gnd/4076769-3, http://d-nb.info/gnd/4020378-5, http://d-nb.info/gnd/4040629-5, Geschichte 71 v. Chr.-70 v. Chr", "http://d-nb.info/gnd/4049788-4", "http://d-nb.info/gnd/4076769-3, http://d-nb.info/gnd/4126078-8, Geschichte 71 v. Chr.-70 v. Chr" ],
   "title" : [ "Ubier, Chatten, Bataver" ],
-  "type" : [ {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  }, {
-    "@id" : "http://purl.org/ontology/bibo/Article"
-  } ]
+  "type" : [ "http://purl.org/ontology/bibo/Article", "http://purl.org/dc/terms/BibliographicResource" ]
 }

--- a/src/test/resources/output/json/01391/HT013911008.json
+++ b/src/test/resources/output/json/01391/HT013911008.json
@@ -1,59 +1,55 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/HT013911008",
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/HT013911008/about",
-    "dateCreated" : "20040202"
+    "dateCreated" : "20040202",
+    "id" : "http://lobid.org/resource/HT013911008/about"
   } ],
   "exemplar" : [ {
-    "@id" : "http://lobid.org/item/HT013911008:DE-361:CB088.87-4144798",
     "callNumber" : "CB088.87-4144798",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT013911008:DE-361:CB088.87-4144798/about"
+      "id" : "http://lobid.org/item/HT013911008:DE-361:CB088.87-4144798/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT013911008",
+    "id" : "http://lobid.org/item/HT013911008:DE-361:CB088.87-4144798",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-361"
+      "id" : "http://lobid.org/organisation/DE-361"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   } ],
   "extent" : [ "1 CD-ROM ; 12 cm + 1 Beih. [6] S." ],
   "hbzId" : [ "HT013911008" ],
+  "id" : "http://lobid.org/resource/HT013911008",
   "inSeries" : [ {
     "numbering" : "5",
     "series" : [ {
-      "@id" : "http://lobid.org/resource/HT013911051"
+      "id" : "http://lobid.org/resource/HT013911051"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/lobid/lv#SeriesRelation"
-    } ]
+    "type" : [ "http://purl.org/lobid/lv#SeriesRelation" ]
   } ],
   "isPartOf" : [ {
-    "@id" : "http://lobid.org/resource/HT013911051"
+    "id" : "http://lobid.org/resource/HT013911051"
   } ],
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT013911008"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT013911008"
   } ],
   "isbn" : [ "3936547041", "9783936547047" ],
   "issued" : [ "2003" ],
   "language" : [ {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
   } ],
   "medium" : [ {
-    "@id" : "http://purl.org/library/CassetteTape"
+    "id" : "http://purl.org/library/CassetteTape"
   }, {
-    "@id" : "http://purl.org/ontology/bibo/AudioDocument"
+    "id" : "http://purl.org/ontology/bibo/AudioDocument"
   } ],
   "placeOfPublication" : [ "Velbert" ],
   "publicationStatement" : [ "Velbert; Eutropia; 2003" ],
   "publisher" : [ "Eutropia" ],
   "sameAs" : [ {
-    "@id" : "http://hub.culturegraph.org/resource/HBZ-HT013911008"
+    "id" : "http://hub.culturegraph.org/resource/HBZ-HT013911008"
   } ],
   "subject" : [ {
-    "@id" : "http://d-nb.info/gnd/4050698-8",
+    "id" : "http://d-nb.info/gnd/4050698-8",
     "preferredName" : "Rothenburg ob der Tauber",
     "preferredNameForThePlaceOrGeographicName" : "Rothenburg ob der Tauber"
   } ],
@@ -61,10 +57,6 @@
   "subjectLabel" : [ "Rothenburg ob der Tauber", "Stadtmagistrat (Rothenburg, Tauber)", "Rothenburg, Tauber", "Rothenburg o.d.T." ],
   "subjectOrder" : [ "http://d-nb.info/gnd/4050698-8, CD-ROM" ],
   "title" : [ "1000 Fotos aus Rothenburg ob der Tauber" ],
-  "type" : [ {
-    "@id" : "http://purl.org/lobid/lv#Miscellaneous"
-  }, {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  } ],
+  "type" : [ "http://purl.org/dc/terms/BibliographicResource", "http://purl.org/lobid/lv#Miscellaneous" ],
   "volume" : [ "5" ]
 }

--- a/src/test/resources/output/json/01401/HT014015351.json
+++ b/src/test/resources/output/json/01401/HT014015351.json
@@ -1,198 +1,170 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/HT014015351",
   "contributor" : [ {
-    "@id" : "http://d-nb.info/gnd/136788548",
+    "id" : "http://d-nb.info/gnd/136788548",
     "preferredName" : "Jäger, Ludwig",
     "preferredNameForThePerson" : "Jäger, Ludwig"
   } ],
   "contributorLabel" : [ "Jäger, Ludwig", "Fehrmann, Gisela" ],
   "contributorOrder" : [ "http://d-nb.info/gnd/129016713 | http://d-nb.info/gnd/136788548" ],
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/HT014015351/about",
-    "dateModified" : "20081128"
+    "dateModified" : "20081128",
+    "id" : "http://lobid.org/resource/HT014015351/about"
   } ],
   "editor" : [ {
-    "@id" : "http://d-nb.info/gnd/129016713",
+    "id" : "http://d-nb.info/gnd/129016713",
     "preferredName" : "Fehrmann, Gisela",
     "preferredNameForThePerson" : "Fehrmann, Gisela"
   } ],
   "exemplar" : [ {
-    "@id" : "http://lobid.org/item/HT014015351:DE-468:BJHJ1028",
-    "callNumber" : "BJHJ1028",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT014015351:DE-468:BJHJ1028/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT014015351",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-468"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT014015351:DE-294:IFB9657",
-    "callNumber" : "IFB9657",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT014015351:DE-294:IFB9657/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT014015351",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-294"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT014015351:DE-Dm13:KKZJ%201",
-    "callNumber" : "KKZJ 1",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT014015351:DE-Dm13:KKZJ%201/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT014015351",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Dm13"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT014015351:DE-361:OH058%20S7L5",
-    "callNumber" : "OH058 S7L5",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT014015351:DE-361:OH058%20S7L5/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT014015351",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-361"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT014015351:DE-Lan1:deu%20503-109",
-    "callNumber" : "deu 503-109",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT014015351:DE-Lan1:deu%20503-109/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT014015351",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Lan1"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT014015351:DE-467:21KKZJ1005",
-    "callNumber" : "21KKZJ1005",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT014015351:DE-467:21KKZJ1005/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT014015351",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-467"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT014015351:DE-5:2010%2F1208",
-    "callNumber" : "2010/1208",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT014015351:DE-5:2010%2F1208/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT014015351",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-5"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT014015351:DE-61:alge910.s772",
     "callNumber" : "alge910.s772",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT014015351:DE-61:alge910.s772/about"
+      "id" : "http://lobid.org/item/HT014015351:DE-61:alge910.s772/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT014015351",
+    "id" : "http://lobid.org/item/HT014015351:DE-61:alge910.s772",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-61"
+      "id" : "http://lobid.org/organisation/DE-61"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT014015351:DE-6:3H%2083949",
-    "callNumber" : "3H 83949",
+    "callNumber" : "2010/1208",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT014015351:DE-6:3H%2083949/about"
+      "id" : "http://lobid.org/item/HT014015351:DE-5:2010%2F1208/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT014015351",
+    "id" : "http://lobid.org/item/HT014015351:DE-5:2010%2F1208",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-6"
+      "id" : "http://lobid.org/organisation/DE-5"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT014015351:DE-Lan1:deu%20503-109a",
+    "callNumber" : "KKZJ 1",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT014015351:DE-Dm13:KKZJ%201/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT014015351",
+    "id" : "http://lobid.org/item/HT014015351:DE-Dm13:KKZJ%201",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-Dm13"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
     "callNumber" : "deu 503-109a",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT014015351:DE-Lan1:deu%20503-109a/about"
+      "id" : "http://lobid.org/item/HT014015351:DE-Lan1:deu%20503-109a/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT014015351",
+    "id" : "http://lobid.org/item/HT014015351:DE-Lan1:deu%20503-109a",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Lan1"
+      "id" : "http://lobid.org/organisation/DE-Lan1"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "IFB9657",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT014015351:DE-294:IFB9657/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT014015351",
+    "id" : "http://lobid.org/item/HT014015351:DE-294:IFB9657",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-294"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "21KKZJ1005",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT014015351:DE-467:21KKZJ1005/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT014015351",
+    "id" : "http://lobid.org/item/HT014015351:DE-467:21KKZJ1005",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-467"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "BJHJ1028",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT014015351:DE-468:BJHJ1028/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT014015351",
+    "id" : "http://lobid.org/item/HT014015351:DE-468:BJHJ1028",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-468"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "OH058 S7L5",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT014015351:DE-361:OH058%20S7L5/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT014015351",
+    "id" : "http://lobid.org/item/HT014015351:DE-361:OH058%20S7L5",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-361"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "3H 83949",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT014015351:DE-6:3H%2083949/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT014015351",
+    "id" : "http://lobid.org/item/HT014015351:DE-6:3H%2083949",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-6"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "deu 503-109",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT014015351:DE-Lan1:deu%20503-109/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT014015351",
+    "id" : "http://lobid.org/item/HT014015351:DE-Lan1:deu%20503-109",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-Lan1"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   } ],
   "extent" : [ "324 S. : Ill." ],
   "hbzId" : [ "HT014015351" ],
   "honoree" : [ {
-    "@id" : "http://d-nb.info/gnd/136788548",
+    "id" : "http://d-nb.info/gnd/136788548",
     "preferredName" : "Jäger, Ludwig",
     "preferredNameForThePerson" : "Jäger, Ludwig"
   } ],
+  "id" : "http://lobid.org/resource/HT014015351",
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT014015351"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT014015351"
   } ],
   "isbn" : [ "9783770538478", "3770538471" ],
   "issued" : [ "2005" ],
   "language" : [ {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
   } ],
   "medium" : [ {
-    "@id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
+    "id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
   } ],
   "otherTitleInformation" : [ "Praktiken des Symbolischen ; [Festschrift für Ludwig Jäger zum 60. Geburtstag]" ],
   "placeOfPublication" : [ "München" ],
   "publicationStatement" : [ "München; Fink; 2005" ],
   "publisher" : [ "Fink" ],
   "sameAs" : [ {
-    "@id" : "http://hub.culturegraph.org/resource/HBZ-HT014015351"
+    "id" : "http://hub.culturegraph.org/resource/HBZ-HT014015351"
   } ],
   "statementOfResponsibility" : [ "hrsg. von Gisela Fehrmann ..." ],
   "subject" : [ {
-    "@id" : "http://d-nb.info/gnd/4604932-0",
+    "id" : "http://d-nb.info/gnd/4604932-0",
     "preferredName" : "Abbild",
     "preferredNameForTheSubjectHeading" : "Abbild"
   }, {
-    "@id" : "http://d-nb.info/gnd/4184194-3",
+    "id" : "http://d-nb.info/gnd/4184194-3",
     "preferredName" : "Symbolik",
     "preferredNameForTheSubjectHeading" : "Symbolik"
   } ],
   "subjectChain" : [ "Abbild | Symbolik | Aufsatzsammlung (213)" ],
   "subjectOrder" : [ "http://d-nb.info/gnd/4604932-0, http://d-nb.info/gnd/4184194-3, Aufsatzsammlung" ],
   "title" : [ "Spuren, Lektüren" ],
-  "type" : [ {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  }, {
-    "@id" : "http://purl.org/ontology/bibo/Book"
-  }, {
-    "@id" : "http://purl.org/lobid/lv#Festschrift"
-  }, {
-    "@id" : "http://purl.org/lobid/lv#EditedVolume"
-  } ]
+  "type" : [ "http://purl.org/ontology/bibo/Book", "http://purl.org/lobid/lv#EditedVolume", "http://purl.org/lobid/lv#Festschrift", "http://purl.org/dc/terms/BibliographicResource" ]
 }

--- a/src/test/resources/output/json/01404/HT014046679.json
+++ b/src/test/resources/output/json/01404/HT014046679.json
@@ -1,65 +1,59 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/HT014046679",
   "contributingCorporateBodyLabel" : [ "Amt für Jugendarbeit", "Evangelische Kirche von Westfalen" ],
   "contributor" : [ {
-    "@id" : "http://d-nb.info/gnd/175894612",
+    "id" : "http://d-nb.info/gnd/175894612",
     "preferredName" : "Hoefler, Angelika",
     "preferredNameForThePerson" : "Hoefler, Angelika"
   }, {
-    "@id" : "http://d-nb.info/gnd/183839064",
+    "id" : "http://d-nb.info/gnd/183839064",
     "preferredName" : "Herrenbrück, Erika",
     "preferredNameForThePerson" : "Herrenbrück, Erika"
   }, {
-    "@id" : "http://d-nb.info/gnd/2095440-2",
+    "id" : "http://d-nb.info/gnd/2095440-2",
     "preferredName" : "Evangelische Kirche von Westfalen. Amt für Jugendarbeit",
     "preferredNameForTheCorporateBody" : "Evangelische Kirche von Westfalen. Amt für Jugendarbeit"
   } ],
   "contributorLabel" : [ "Hoefler, Angelika", "Herrenbrück, Erika" ],
   "contributorOrder" : [ "http://d-nb.info/gnd/183839064 | http://d-nb.info/gnd/175894612 | http://d-nb.info/gnd/2095440-2" ],
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/HT014046679/about",
     "dateCreated" : "20040615",
-    "dateModified" : "20041018"
+    "dateModified" : "20041018",
+    "id" : "http://lobid.org/resource/HT014046679/about"
   } ],
   "exemplar" : [ {
-    "@id" : "http://lobid.org/item/HT014046679:DE-Bi10:ICE%20Brav",
     "callNumber" : "ICE Brav",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT014046679:DE-Bi10:ICE%20Brav/about"
+      "id" : "http://lobid.org/item/HT014046679:DE-Bi10:ICE%20Brav/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT014046679",
+    "id" : "http://lobid.org/item/HT014046679:DE-Bi10:ICE%20Brav",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Bi10"
+      "id" : "http://lobid.org/organisation/DE-Bi10"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   } ],
   "extent" : [ "1 Spiel (Inhalt: 1 Spielanleitung, 100 Situationskarten: 60 für Frauen, 40 für Mädchen (ab 12 J.). 90 Brave-Karten, 90 Böse-Karten)" ],
   "hbzId" : [ "HT014046679" ],
+  "id" : "http://lobid.org/resource/HT014046679",
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT014046679"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT014046679"
   } ],
   "issued" : [ "1997" ],
   "language" : [ {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
   } ],
   "medium" : [ {
-    "@id" : "http://purl.org/lobid/lv#Miscellaneous"
+    "id" : "http://purl.org/lobid/lv#Miscellaneous"
   } ],
   "otherTitleInformation" : [ "das Kommunikationsspiel zur Bewertung weiblichen Verhaltens für 2 - 8 Spielerinnen" ],
   "placeOfPublication" : [ "Hennef" ],
   "publicationStatement" : [ "Hennef; INVENTION; 1997" ],
   "publisher" : [ "INVENTION" ],
   "sameAs" : [ {
-    "@id" : "http://hub.culturegraph.org/resource/HBZ-HT014046679"
+    "id" : "http://hub.culturegraph.org/resource/HBZ-HT014046679"
   } ],
   "statementOfResponsibility" : [ "Idee und Konzeption: Erika Herrenbrück. Texte: Angelika Hoefler" ],
   "title" : [ "Brave Mädchen - Böse Mädchen" ],
-  "type" : [ {
-    "@id" : "http://purl.org/library/Game"
-  }, {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  } ]
+  "type" : [ "http://purl.org/dc/terms/BibliographicResource", "http://purl.org/library/Game" ]
 }

--- a/src/test/resources/output/json/01421/HT014215912.json
+++ b/src/test/resources/output/json/01421/HT014215912.json
@@ -1,65 +1,61 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/HT014215912",
   "bibliographicCitation" : [ "Karl der Große und Europa / hrsg. von der Schweizerischen Botschaft in der Bundesrepublik Deutschland ... - Frankfurt am Main [u.a.], 2004. - S. 67-86 : Ill." ],
   "collectedBy" : [ {
-    "@id" : "http://lobid.org/resource/NWBib"
+    "id" : "http://lobid.org/resource/NWBib"
   } ],
   "containedIn" : [ {
-    "@id" : "http://lobid.org/resource/HT014168843"
+    "id" : "http://lobid.org/resource/HT014168843"
   } ],
   "contributorLabel" : [ "Lüken, Sven" ],
   "contributorOrder" : [ "http://d-nb.info/gnd/121815684" ],
   "creator" : [ {
-    "@id" : "http://d-nb.info/gnd/121815684",
+    "id" : "http://d-nb.info/gnd/121815684",
     "preferredName" : "Lüken, Sven",
     "preferredNameForThePerson" : "Lüken, Sven"
   } ],
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/HT014215912/about",
-    "dateCreated" : "20041208"
+    "dateCreated" : "20041208",
+    "id" : "http://lobid.org/resource/HT014215912/about"
   } ],
   "hbzId" : [ "HT014215912" ],
+  "id" : "http://lobid.org/resource/HT014215912",
   "isPartOf" : [ {
-    "@id" : "http://lobid.org/resource/HT014168843"
+    "id" : "http://lobid.org/resource/HT014168843"
   } ],
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT014215912"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT014215912"
   } ],
   "issued" : [ "2004" ],
   "language" : [ {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
   } ],
   "medium" : [ {
-    "@id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
+    "id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
   } ],
   "nwbibspatial" : [ {
-    "@id" : "http://purl.org/lobid/nwbib-spatial#n01"
+    "id" : "http://purl.org/lobid/nwbib-spatial#n01"
   } ],
   "nwbibsubject" : [ {
-    "@id" : "http://purl.org/lobid/nwbib#s240000"
+    "id" : "http://purl.org/lobid/nwbib#s240000"
   } ],
   "publicationStatement" : [ "2004" ],
   "sameAs" : [ {
-    "@id" : "http://hub.culturegraph.org/resource/HBZ-HT014215912"
+    "id" : "http://hub.culturegraph.org/resource/HBZ-HT014215912"
   } ],
   "statementOfResponsibility" : [ "Sven Lüken" ],
   "subject" : [ {
-    "@id" : "http://d-nb.info/gnd/118560034",
-    "preferredName" : "Karl, I., Heiliges Römisches Reich, Kaiser",
-    "preferredNameForThePerson" : "Karl, I., Heiliges Römisches Reich, Kaiser"
-  }, {
-    "@id" : "http://d-nb.info/gnd/4159648-1",
+    "id" : "http://d-nb.info/gnd/4159648-1",
     "preferredName" : "Herrscherbild",
     "preferredNameForTheSubjectHeading" : "Herrscherbild"
+  }, {
+    "id" : "http://d-nb.info/gnd/118560034",
+    "preferredName" : "Karl, I., Heiliges Römisches Reich, Kaiser",
+    "preferredNameForThePerson" : "Karl, I., Heiliges Römisches Reich, Kaiser"
   } ],
   "subjectChain" : [ "Karl | Heiliges Römisches Reich, Kaiser | Herrscherbild | Geschichte (213)" ],
   "subjectLabel" : [ "le Grand (747-814)", "Germania, Imperator (747-814)", "Mór (747-814)", "Magnus (747-814)", "Magno (747-814)", "the Great (747-814)", "Carlomagno (747-814)", "Römischer Kaiser (747-814)", "Franken, König (747-814)", "Karlmeinet (747-814)", "der Große (747-814)", "Charlemaigne (747-814)", "Magnus Germanus (747-814)", "Charlemagne (747-814)", "Heiliges Römisches Reich, Kaiser (747-814)", "Imperium Romanum-Germanicum, Imperator (747-814)", "Römisches Reich, Kaiser I. (747-814)", "Charlemaine (747-814)" ],
   "subjectOrder" : [ "http://d-nb.info/gnd/118560034, http://d-nb.info/gnd/4159648-1, Geschichte" ],
   "title" : [ "Karl der Große und sein Bild" ],
-  "type" : [ {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  }, {
-    "@id" : "http://purl.org/ontology/bibo/Article"
-  } ]
+  "type" : [ "http://purl.org/ontology/bibo/Article", "http://purl.org/dc/terms/BibliographicResource" ]
 }

--- a/src/test/resources/output/json/01431/HT014319164.json
+++ b/src/test/resources/output/json/01431/HT014319164.json
@@ -1,11 +1,10 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/HT014319164",
   "collectedBy" : [ {
-    "@id" : "http://lobid.org/resource/NWBib"
+    "id" : "http://lobid.org/resource/NWBib"
   } ],
   "contributor" : [ {
-    "@id" : "http://d-nb.info/gnd/159865794",
+    "id" : "http://d-nb.info/gnd/159865794",
     "preferredName" : "Adenauer, Konrad",
     "preferredNameForThePerson" : "Adenauer, Konrad"
   } ],
@@ -13,81 +12,74 @@
   "contributorOrder" : [ "http://d-nb.info/gnd/133595935 | http://d-nb.info/gnd/159865794" ],
   "coverage" : [ "Bad Honnef", "Köln" ],
   "creator" : [ {
-    "@id" : "http://d-nb.info/gnd/133595935",
+    "id" : "http://d-nb.info/gnd/133595935",
     "preferredName" : "Reinarz, Titus",
     "preferredNameForThePerson" : "Reinarz, Titus"
   } ],
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/HT014319164/about",
     "dateCreated" : "20050322",
-    "dateModified" : "20130117"
+    "dateModified" : "20130117",
+    "id" : "http://lobid.org/resource/HT014319164/about"
   } ],
   "exemplar" : [ {
-    "@id" : "http://lobid.org/item/HT014319164:DE-929:2005%2F1952",
     "callNumber" : "2005/1952",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT014319164:DE-929:2005%2F1952/about"
+      "id" : "http://lobid.org/item/HT014319164:DE-929:2005%2F1952/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT014319164",
+    "id" : "http://lobid.org/item/HT014319164:DE-929:2005%2F1952",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-929"
+      "id" : "http://lobid.org/organisation/DE-929"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT014319164:DE-38:17B2432",
     "callNumber" : "17B2432",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT014319164:DE-38:17B2432/about"
+      "id" : "http://lobid.org/item/HT014319164:DE-38:17B2432/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT014319164",
+    "id" : "http://lobid.org/item/HT014319164:DE-38:17B2432",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-38"
+      "id" : "http://lobid.org/organisation/DE-38"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   } ],
   "extent" : [ "183 S. : überw. Ill." ],
   "hbzId" : [ "HT014319164" ],
+  "id" : "http://lobid.org/resource/HT014319164",
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT014319164"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT014319164"
   } ],
   "issued" : [ "1998" ],
   "language" : [ {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
   } ],
   "medium" : [ {
-    "@id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
+    "id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
   } ],
   "nwbibsubject" : [ {
-    "@id" : "http://purl.org/lobid/nwbib#s841070"
+    "id" : "http://purl.org/lobid/nwbib#s841070"
   } ],
   "otherTitleInformation" : [ "Bildhauer" ],
   "placeOfPublication" : [ "[Sinzig]" ],
   "publicationStatement" : [ "[Sinzig]; [Selbstverl.]; 1998" ],
   "publisher" : [ "[Selbstverl.]" ],
   "sameAs" : [ {
-    "@id" : "http://hub.culturegraph.org/resource/HBZ-HT014319164"
+    "id" : "http://hub.culturegraph.org/resource/HBZ-HT014319164"
   } ],
   "statementOfResponsibility" : [ "[Textbeitr. Konrad Adenauer ...]" ],
   "subject" : [ {
-    "@id" : "http://d-nb.info/gnd/4046277-8",
-    "preferredName" : "Plastik",
-    "preferredNameForTheSubjectHeading" : "Plastik"
-  }, {
-    "@id" : "http://d-nb.info/gnd/133595935",
+    "id" : "http://d-nb.info/gnd/133595935",
     "preferredName" : "Reinarz, Titus",
     "preferredNameForThePerson" : "Reinarz, Titus"
+  }, {
+    "id" : "http://d-nb.info/gnd/4046277-8",
+    "preferredName" : "Plastik",
+    "preferredNameForTheSubjectHeading" : "Plastik"
   } ],
   "subjectChain" : [ "Reinarz, Titus | Plastik | Bildband" ],
   "subjectLabel" : [ "Bildhauerkunst", "Skulpturen", "Bildwerk", "Skulptur", "Plastiken" ],
   "subjectOrder" : [ "http://d-nb.info/gnd/133595935, http://d-nb.info/gnd/4046277-8, Bildband" ],
   "title" : [ "Titus Reinarz" ],
-  "type" : [ {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  }, {
-    "@id" : "http://purl.org/ontology/bibo/Book"
-  } ]
+  "type" : [ "http://purl.org/ontology/bibo/Book", "http://purl.org/dc/terms/BibliographicResource" ]
 }

--- a/src/test/resources/output/json/01452/HT014525099.json
+++ b/src/test/resources/output/json/01452/HT014525099.json
@@ -1,86 +1,80 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/HT014525099",
   "contributingCorporateBodyLabel" : [ "Neues Bach'sches Collegium Musicum", "New Leipzig Bach Collegium Musicum", "Thomaner Chor", "Neues Bachisches Collegium Musicum", "Thomanerchor", "Thomaner" ],
   "contributor" : [ {
-    "@id" : "http://d-nb.info/gnd/1212749-8",
+    "id" : "http://d-nb.info/gnd/1212749-8",
     "preferredName" : "Thomanerchor",
     "preferredNameForTheCorporateBody" : "Thomanerchor"
   }, {
-    "@id" : "http://d-nb.info/gnd/806366-7",
+    "id" : "http://d-nb.info/gnd/806366-7",
     "preferredName" : "Neues Bachisches Collegium Musicum <Leipzig>",
     "preferredNameForTheCorporateBody" : "Neues Bachisches Collegium Musicum <Leipzig>"
   } ],
   "contributorLabel" : [ "Adam, Theo Siegfried", "Bach, ...", "Rotzsch, Hans-Joachim", "Augér, Arleen", "Bach, Jean-Sebastien", "Bach, Joh. Sebastian", "Schreier, P.", "Šrajer, Peter", "Bach, Jan Sebastian", "Bach, Joh. Seb.", "Bach, Johann Seb.", "Bach, Johann-Sebastian", "Bach, G. S.", "Adam, Theo", "Bach, Johannes Sebastian", "Bach, Johann Sebastian", "Bach, Johannes S.", "Bach, Johann S.", "Bach, Sebastian", "Rotzsch, Hans Joachim", "Bach, Joh.-Seb.", "Bach, Jean S.", "Bach, Giovanni Sebastiano", "Bach, Iogann Sebastʹjan", "Ože, Arlen", "Rotzsch, Hans J.", "Bach, J. S.", "Schreier, Peter", "Bach, Joh. Sebas.", "Bach, Jean-Sébastien", "Wenkel, Ortrun", "Shuraiya, Pētā", "Bach, Joh. Sebast." ],
   "contributorOrder" : [ "http://d-nb.info/gnd/11850553X | http://d-nb.info/gnd/129389641 | http://d-nb.info/gnd/128992204 | http://d-nb.info/gnd/118610724 | http://d-nb.info/gnd/118500546 | http://d-nb.info/gnd/118867539 | http://d-nb.info/gnd/1212749-8 | http://d-nb.info/gnd/806366-7" ],
   "creator" : [ {
-    "@id" : "http://d-nb.info/gnd/118610724",
-    "preferredName" : "Schreier, Peter",
-    "preferredNameForThePerson" : "Schreier, Peter"
-  }, {
-    "@id" : "http://d-nb.info/gnd/118500546",
-    "preferredName" : "Adam, Theo",
-    "preferredNameForThePerson" : "Adam, Theo"
-  }, {
-    "@id" : "http://d-nb.info/gnd/118867539",
-    "preferredName" : "Rotzsch, Hans-Joachim",
-    "preferredNameForThePerson" : "Rotzsch, Hans-Joachim"
-  }, {
-    "@id" : "http://d-nb.info/gnd/129389641",
-    "preferredName" : "Augér, Arleen",
-    "preferredNameForThePerson" : "Augér, Arleen"
-  }, {
-    "@id" : "http://d-nb.info/gnd/11850553X",
+    "id" : "http://d-nb.info/gnd/11850553X",
     "preferredName" : "Bach, Johann Sebastian",
     "preferredNameForThePerson" : "Bach, Johann Sebastian"
   }, {
-    "@id" : "http://d-nb.info/gnd/128992204",
+    "id" : "http://d-nb.info/gnd/118610724",
+    "preferredName" : "Schreier, Peter",
+    "preferredNameForThePerson" : "Schreier, Peter"
+  }, {
+    "id" : "http://d-nb.info/gnd/118500546",
+    "preferredName" : "Adam, Theo",
+    "preferredNameForThePerson" : "Adam, Theo"
+  }, {
+    "id" : "http://d-nb.info/gnd/129389641",
+    "preferredName" : "Augér, Arleen",
+    "preferredNameForThePerson" : "Augér, Arleen"
+  }, {
+    "id" : "http://d-nb.info/gnd/118867539",
+    "preferredName" : "Rotzsch, Hans-Joachim",
+    "preferredNameForThePerson" : "Rotzsch, Hans-Joachim"
+  }, {
+    "id" : "http://d-nb.info/gnd/128992204",
     "preferredName" : "Wenkel, Ortrun",
     "preferredNameForThePerson" : "Wenkel, Ortrun"
   } ],
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/HT014525099/about"
+    "id" : "http://lobid.org/resource/HT014525099/about"
   } ],
   "exemplar" : [ {
-    "@id" : "http://lobid.org/item/HT014525099:DE-1156:AR%20ba%2071",
     "callNumber" : "AR ba 71",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT014525099:DE-1156:AR%20ba%2071/about"
+      "id" : "http://lobid.org/item/HT014525099:DE-1156:AR%20ba%2071/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT014525099",
+    "id" : "http://lobid.org/item/HT014525099:DE-1156:AR%20ba%2071",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-1156"
+      "id" : "http://lobid.org/organisation/DE-1156"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   } ],
   "extent" : [ "2 Schallpl. : 33 UpM, stereo ; 30 cm" ],
   "hbzId" : [ "HT014525099" ],
+  "id" : "http://lobid.org/resource/HT014525099",
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT014525099"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT014525099"
   } ],
   "issued" : [ "1981" ],
   "language" : [ {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
   } ],
   "medium" : [ {
-    "@id" : "http://purl.org/ontology/mo/Vinyl"
+    "id" : "http://purl.org/ontology/mo/Vinyl"
   }, {
-    "@id" : "http://purl.org/ontology/bibo/AudioDocument"
+    "id" : "http://purl.org/ontology/bibo/AudioDocument"
   } ],
   "otherTitleInformation" : [ "Christ lag in Todesbanden BWV 4 ; Ein Herz, da seinen Jesum lebend weiß BWV 134 ; Erschallet, ihr Lieder BWV 172 ; Also hat Gott die Welt geliebt BWV 68" ],
   "placeOfPublication" : [ "Berlin" ],
   "publicationStatement" : [ "Berlin; Dt. Schallplatten; 1981" ],
   "publisher" : [ "Dt. Schallplatten" ],
   "sameAs" : [ {
-    "@id" : "http://hub.culturegraph.org/resource/HBZ-HT014525099"
+    "id" : "http://hub.culturegraph.org/resource/HBZ-HT014525099"
   } ],
   "statementOfResponsibility" : [ "Johann Sebastian Bach" ],
   "title" : [ "Kantaten Ostern, Pfingsten" ],
-  "type" : [ {
-    "@id" : "http://purl.org/ontology/mo/PublishedScore"
-  }, {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  } ]
+  "type" : [ "http://purl.org/dc/terms/BibliographicResource", "http://purl.org/ontology/mo/PublishedScore" ]
 }

--- a/src/test/resources/output/json/01499/HT014997977.json
+++ b/src/test/resources/output/json/01499/HT014997977.json
@@ -1,69 +1,63 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/HT014997977",
   "collectedBy" : [ {
-    "@id" : "http://lobid.org/resource/RPB"
+    "id" : "http://lobid.org/resource/RPB"
   }, {
-    "@id" : "http://lobid.org/resource/Edoweb"
+    "id" : "http://lobid.org/resource/Edoweb"
   } ],
   "contributingCorporateBodyLabel" : [ "Landesbetrieb Straßen und Verkehr Rheinland-Pfalz", "Arbeitskreis Straßenbauabfälle Rheinland-Pfalz", "Landesamt für Umwelt und Gewerbeaufsicht", "Landesbetrieb Straßen und Verkehr RP", "LfUG", "Rheinland-Pfalz", "Landesamt für Umweltschutz und Gewerbeaufsicht", "LSV" ],
   "contributor" : [ {
-    "@id" : "http://d-nb.info/gnd/3062366-2",
+    "id" : "http://d-nb.info/gnd/3062366-2",
     "preferredName" : "Arbeitskreis Straßenbauabfälle Rheinland-Pfalz",
     "preferredNameForTheCorporateBody" : "Arbeitskreis Straßenbauabfälle Rheinland-Pfalz"
   }, {
-    "@id" : "http://d-nb.info/gnd/10048424-4",
+    "id" : "http://d-nb.info/gnd/10048424-4",
     "preferredName" : "Landesbetrieb Straßen und Verkehr Rheinland-Pfalz <Koblenz>",
     "preferredNameForTheCorporateBody" : "Landesbetrieb Straßen und Verkehr Rheinland-Pfalz <Koblenz>"
   }, {
-    "@id" : "http://d-nb.info/gnd/2092393-4",
+    "id" : "http://d-nb.info/gnd/2092393-4",
     "preferredName" : "Rheinland-Pfalz <Koblenz>. Landesamt für Umweltschutz und Gewerbeaufsicht",
     "preferredNameForTheCorporateBody" : "Rheinland-Pfalz <Koblenz>. Landesamt für Umweltschutz und Gewerbeaufsicht"
   } ],
   "contributorOrder" : [ "http://d-nb.info/gnd/3062366-2 | http://d-nb.info/gnd/10048424-4 | http://d-nb.info/gnd/2092393-4" ],
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/HT014997977/about",
-    "dateCreated" : "20070222"
+    "dateCreated" : "20070222",
+    "id" : "http://lobid.org/resource/HT014997977/about"
   } ],
   "edition" : [ "1. Aufl." ],
   "extent" : [ "15, [14] S. : graph. Darst." ],
   "fulltextOnline" : [ {
-    "@id" : "http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=1750752&custom_att_2=simple_viewer"
+    "id" : "http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=1750752&custom_att_2=simple_viewer"
   } ],
   "hasVersion" : [ {
-    "@id" : "http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=1750752&custom_att_2=simple_viewer"
+    "id" : "http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=1750752&custom_att_2=simple_viewer"
   } ],
   "hbzId" : [ "HT014997977" ],
+  "id" : "http://lobid.org/resource/HT014997977",
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT014997977"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT014997977"
   } ],
   "issued" : [ "2003" ],
   "language" : [ {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
   } ],
   "medium" : [ {
-    "@id" : "http://rdvocab.info/termList/RDACarrierType/1018"
+    "id" : "http://rdvocab.info/termList/RDACarrierType/1018"
   }, {
-    "@id" : "http://rdvocab.info/termList/RDACarrierType/1010"
+    "id" : "http://rdvocab.info/termList/RDACarrierType/1010"
   } ],
   "otherTitleInformation" : [ "Leitfaden für den Geschäftsbereich des Landesbetriebes Straßen und Verkehr" ],
   "placeOfPublication" : [ "[Mainz]" ],
   "publicationStatement" : [ "[Mainz]; 2003" ],
   "sameAs" : [ {
-    "@id" : "http://hub.culturegraph.org/resource/HBZ-HT014997977"
+    "id" : "http://hub.culturegraph.org/resource/HBZ-HT014997977"
   } ],
   "statementOfResponsibility" : [ "Arbeitskreis Straßenbauabfälle Rheinland-Pfalz; Landesamt für Umweltschutz und Gewerbeaufsicht; Landesbetrieb Straßen und Verkehr Rheinland-Pfalz" ],
   "subject" : [ {
-    "@id" : "http://dewey.info/class/380/"
+    "id" : "http://dewey.info/class/380/"
   }, {
-    "@id" : "http://purl.org/lobid/rpb#n574040"
+    "id" : "http://purl.org/lobid/rpb#n574040"
   } ],
   "title" : [ "Leitfaden für die Behandlung von Ausbauasphalt und Straßenaufbruch mit teer-/pechtypischen Bestandteilen" ],
-  "type" : [ {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  }, {
-    "@id" : "http://purl.org/ontology/bibo/Thesis"
-  }, {
-    "@id" : "http://purl.org/ontology/bibo/Book"
-  } ]
+  "type" : [ "http://purl.org/ontology/bibo/Book", "http://purl.org/dc/terms/BibliographicResource", "http://purl.org/ontology/bibo/Thesis" ]
 }

--- a/src/test/resources/output/json/01508/HT015082724.json
+++ b/src/test/resources/output/json/01508/HT015082724.json
@@ -1,50 +1,48 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/HT015082724",
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/HT015082724/about",
-    "dateCreated" : "20070508"
+    "dateCreated" : "20070508",
+    "id" : "http://lobid.org/resource/HT015082724/about"
   } ],
   "exemplar" : [ {
-    "@id" : "http://lobid.org/item/HT015082724:DE-361:CA000%20T340%5B119",
     "callNumber" : "CA000 T340[119",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT015082724:DE-361:CA000%20T340%5B119/about"
+      "id" : "http://lobid.org/item/HT015082724:DE-361:CA000%20T340%5B119/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT015082724",
+    "id" : "http://lobid.org/item/HT015082724:DE-361:CA000%20T340%5B119",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-361"
+      "id" : "http://lobid.org/organisation/DE-361"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   } ],
   "hbzId" : [ "HT015082724" ],
+  "id" : "http://lobid.org/resource/HT015082724",
   "isPartOf" : [ {
-    "@id" : "http://lobid.org/resource/HT001373475"
+    "id" : "http://lobid.org/resource/HT001373475"
   }, {
-    "@id" : "http://ld.zdb-services.de/resource/208524-0"
+    "id" : "http://ld.zdb-services.de/resource/208524-0"
   } ],
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT015082724"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT015082724"
   } ],
   "issued" : [ "2006" ],
   "language" : [ {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/nld"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/nld"
   } ],
   "medium" : [ {
-    "@id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
+    "id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
   } ],
   "placeOfPublication" : [ "Assen" ],
   "publicationStatement" : [ "Assen; Van Gorcum; 2006" ],
   "publisher" : [ "Van Gorcum" ],
   "sameAs" : [ {
-    "@id" : "http://hub.culturegraph.org/resource/HBZ-HT015082724"
+    "id" : "http://hub.culturegraph.org/resource/HBZ-HT015082724"
   } ],
   "subject" : [ {
-    "@id" : "http://dewey.info/class/900/"
+    "id" : "http://dewey.info/class/900/"
   }, {
-    "@id" : "http://d-nb.info/gnd/4042203-3",
+    "id" : "http://d-nb.info/gnd/4042203-3",
     "preferredName" : "Niederlande",
     "preferredNameForThePlaceOrGeographicName" : "Niederlande"
   } ],
@@ -52,19 +50,13 @@
   "subjectLabel" : [ "Batavische Republik", "Vereinigte Niederlande", "Staat Holland" ],
   "subjectOrder" : [ "http://d-nb.info/gnd/4042203-3, Geschichte, Zeitschrift" ],
   "title" : [ "Tijdschrift voor geschiedenis, 119" ],
-  "type" : [ {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  }, {
-    "@id" : "http://purl.org/ontology/bibo/Book"
-  } ],
+  "type" : [ "http://purl.org/ontology/bibo/Book", "http://purl.org/dc/terms/BibliographicResource" ],
   "volume" : [ "119. 2006", "119" ],
   "volumeIn" : [ {
     "multiVolumeWork" : [ {
-      "@id" : "http://lobid.org/resource/HT001373475"
+      "id" : "http://lobid.org/resource/HT001373475"
     } ],
     "numbering" : "119",
-    "type" : [ {
-      "@id" : "http://purl.org/lobid/lv#MultiVolumeWorkRelation"
-    } ]
+    "type" : [ "http://purl.org/lobid/lv#MultiVolumeWorkRelation" ]
   } ]
 }

--- a/src/test/resources/output/json/01518/HT015183529.json
+++ b/src/test/resources/output/json/01518/HT015183529.json
@@ -1,72 +1,64 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/HT015183529",
   "contributorLabel" : [ "Scott Fitzgerald, F.", "Bruccoli, Matthew Joseph", "Ficǆeralds, Skots Frānsiss", "Fitzgerald, Francis Scott Key", "Scott Fitzgerald, Francis", "Scott-Fitzgerald, Francis", "Bruccoli, Matthew J.", "Fitzgerald, F. Scott", "Fitzgerald, Francis S.", "Fitzgerald, Scott F.", "Fitzgerald, Francis Scott", "Fitzgerald, Scott", "Fitzgerald, F. S." ],
   "contributorOrder" : [ "http://d-nb.info/gnd/118533592 | http://d-nb.info/gnd/119468476" ],
   "creator" : [ {
-    "@id" : "http://d-nb.info/gnd/118533592",
+    "id" : "http://d-nb.info/gnd/118533592",
     "preferredName" : "Fitzgerald, Francis Scott",
     "preferredNameForThePerson" : "Fitzgerald, Francis Scott"
   } ],
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/HT015183529/about",
-    "dateCreated" : "20070618"
+    "dateCreated" : "20070618",
+    "id" : "http://lobid.org/resource/HT015183529/about"
   } ],
   "edition" : [ "12. print." ],
   "editor" : [ {
-    "@id" : "http://d-nb.info/gnd/119468476",
+    "id" : "http://d-nb.info/gnd/119468476",
     "preferredName" : "Bruccoli, Matthew Joseph",
     "preferredNameForThePerson" : "Bruccoli, Matthew Joseph"
   } ],
   "exemplar" : [ {
-    "@id" : "http://lobid.org/item/HT015183529:DE-5:2007%2F4575",
     "callNumber" : "2007/4575",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT015183529:DE-5:2007%2F4575/about"
+      "id" : "http://lobid.org/item/HT015183529:DE-5:2007%2F4575/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT015183529",
+    "id" : "http://lobid.org/item/HT015183529:DE-5:2007%2F4575",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-5"
+      "id" : "http://lobid.org/organisation/DE-5"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   } ],
   "extent" : [ "LV, 225 S. : Kt." ],
   "hbzId" : [ "HT015183529" ],
+  "id" : "http://lobid.org/resource/HT015183529",
   "inSeries" : [ {
     "series" : [ {
-      "@id" : "http://lobid.org/resource/HT004984061"
+      "id" : "http://lobid.org/resource/HT004984061"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/lobid/lv#SeriesRelation"
-    } ]
+    "type" : [ "http://purl.org/lobid/lv#SeriesRelation" ]
   } ],
   "isPartOf" : [ {
-    "@id" : "http://lobid.org/resource/HT004984061"
+    "id" : "http://lobid.org/resource/HT004984061"
   } ],
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT015183529"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT015183529"
   } ],
   "isbn" : [ "0521402301", "9780521402309" ],
   "issued" : [ "2006" ],
   "language" : [ {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/eng"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/eng"
   } ],
   "medium" : [ {
-    "@id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
+    "id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
   } ],
   "placeOfPublication" : [ "Cambridge [u.a.]" ],
   "publicationStatement" : [ "Cambridge [u.a.]; Cambridge Univ. Press; 2006" ],
   "publisher" : [ "Cambridge Univ. Press" ],
   "sameAs" : [ {
-    "@id" : "http://hub.culturegraph.org/resource/HBZ-HT015183529"
+    "id" : "http://hub.culturegraph.org/resource/HBZ-HT015183529"
   } ],
   "statementOfResponsibility" : [ "F. Scott Fitzgerald. Ed. by Matthew J. Bruccoli" ],
   "title" : [ "The great Gatsby" ],
-  "type" : [ {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  }, {
-    "@id" : "http://purl.org/ontology/bibo/Book"
-  } ]
+  "type" : [ "http://purl.org/ontology/bibo/Book", "http://purl.org/dc/terms/BibliographicResource" ]
 }

--- a/src/test/resources/output/json/01541/HT015414894.json
+++ b/src/test/resources/output/json/01541/HT015414894.json
@@ -1,66 +1,60 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/HT015414894",
   "bibliographicCitation" : [ "Medien und Terrorismus; Christian Schicha ... (Hg.); 2002; S. 80 - 93" ],
   "containedIn" : [ {
-    "@id" : "http://lobid.org/resource/HT013384949"
+    "id" : "http://lobid.org/resource/HT013384949"
   } ],
   "contributorLabel" : [ "Kim, Richard", "Werthes, Sascha", "Conrad, Christoph" ],
   "contributorOrder" : [ "http://d-nb.info/gnd/122021878 | http://d-nb.info/gnd/186186193 | http://d-nb.info/gnd/11075851X" ],
   "creator" : [ {
-    "@id" : "http://d-nb.info/gnd/186186193",
+    "id" : "http://d-nb.info/gnd/186186193",
     "preferredName" : "Kim, Richard",
     "preferredNameForThePerson" : "Kim, Richard"
   }, {
-    "@id" : "http://d-nb.info/gnd/11075851X",
+    "id" : "http://d-nb.info/gnd/11075851X",
     "preferredName" : "Conrad, Christoph",
     "preferredNameForThePerson" : "Conrad, Christoph"
   }, {
-    "@id" : "http://d-nb.info/gnd/122021878",
+    "id" : "http://d-nb.info/gnd/122021878",
     "preferredName" : "Werthes, Sascha",
     "preferredNameForThePerson" : "Werthes, Sascha"
   } ],
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/HT015414894/about"
+    "id" : "http://lobid.org/resource/HT015414894/about"
   } ],
   "exemplar" : [ {
-    "@id" : "http://lobid.org/item/HT015414894:DE-6:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT015414894:DE-6:/about"
+      "id" : "http://lobid.org/item/HT015414894:DE-6:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT015414894",
+    "id" : "http://lobid.org/item/HT015414894:DE-6:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-6"
+      "id" : "http://lobid.org/organisation/DE-6"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   } ],
   "hbzId" : [ "HT015414894" ],
+  "id" : "http://lobid.org/resource/HT015414894",
   "isPartOf" : [ {
-    "@id" : "http://lobid.org/resource/HT013384949"
+    "id" : "http://lobid.org/resource/HT013384949"
   } ],
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT015414894"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT015414894"
   } ],
   "issued" : [ "2002" ],
   "language" : [ {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
   } ],
   "medium" : [ {
-    "@id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
+    "id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
   } ],
   "otherTitleInformation" : [ "Internationale Krisenkommunikation - eine Herausforderung im 21. Jahrhundert" ],
   "placeOfPublication" : [ "Münster [u.a.]" ],
   "publicationStatement" : [ "2002; Münster [u.a.]" ],
   "sameAs" : [ {
-    "@id" : "http://hub.culturegraph.org/resource/HBZ-HT015414894"
+    "id" : "http://hub.culturegraph.org/resource/HBZ-HT015414894"
   } ],
   "statementOfResponsibility" : [ "Sascha Werthes ; Richard Kim ; Christoph Conrad" ],
   "title" : [ "Die Terrorkrise als Medienereignis?" ],
-  "type" : [ {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  }, {
-    "@id" : "http://purl.org/ontology/bibo/Article"
-  } ]
+  "type" : [ "http://purl.org/ontology/bibo/Article", "http://purl.org/dc/terms/BibliographicResource" ]
 }

--- a/src/test/resources/output/json/01544/HT015440386.json
+++ b/src/test/resources/output/json/01544/HT015440386.json
@@ -1,92 +1,84 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/HT015440386",
   "contributorLabel" : [ "König, R.", "König, Ralf" ],
   "contributorOrder" : [ "http://d-nb.info/gnd/111614597" ],
   "creator" : [ {
-    "@id" : "http://d-nb.info/gnd/111614597",
+    "id" : "http://d-nb.info/gnd/111614597",
     "preferredName" : "König, Ralf",
     "preferredNameForThePerson" : "König, Ralf"
   } ],
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/HT015440386/about",
-    "dateCreated" : "20080220"
+    "dateCreated" : "20080220",
+    "id" : "http://lobid.org/resource/HT015440386/about"
   } ],
   "edition" : [ "Orig.-Ausg., 31. - 40. Tsd." ],
   "exemplar" : [ {
-    "@id" : "http://lobid.org/item/HT015440386:DE-385-AN:C%2Fld487",
     "callNumber" : "C/ld487",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT015440386:DE-385-AN:C%2Fld487/about"
+      "id" : "http://lobid.org/item/HT015440386:DE-385-AN:C%2Fld487/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT015440386",
+    "id" : "http://lobid.org/item/HT015440386:DE-385-AN:C%2Fld487",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-385-AN"
+      "id" : "http://lobid.org/organisation/DE-385-AN"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   } ],
   "extent" : [ "181, VIII S." ],
   "hbzId" : [ "HT015440386" ],
+  "id" : "http://lobid.org/resource/HT015440386",
   "inSeries" : [ {
     "numbering" : "22392",
     "series" : [ {
-      "@id" : "http://lobid.org/resource/HT002091108"
+      "id" : "http://lobid.org/resource/HT002091108"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/lobid/lv#SeriesRelation"
-    } ]
+    "type" : [ "http://purl.org/lobid/lv#SeriesRelation" ]
   } ],
   "isPartOf" : [ {
-    "@id" : "http://lobid.org/resource/HT002091108"
+    "id" : "http://lobid.org/resource/HT002091108"
   } ],
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT015440386"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT015440386"
   } ],
   "isbn" : [ "3499223929", "9783499223921" ],
   "issued" : [ "1998" ],
   "language" : [ {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
   } ],
   "medium" : [ {
-    "@id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
+    "id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
   } ],
   "nwbibspatial" : [ {
-    "@id" : "http://purl.org/lobid/nwbib-spatial#n01"
+    "id" : "http://purl.org/lobid/nwbib-spatial#n01"
   } ],
   "nwbibsubject" : [ {
-    "@id" : "http://purl.org/lobid/nwbib#s841070"
+    "id" : "http://purl.org/lobid/nwbib#s841070"
   } ],
   "otherTitleInformation" : [ "Comic ; [nach Motiven aus den Dramen Othello, Macbeth, Romeo & Julia und Ein Sommernachtstraum von William Shakespeare]" ],
   "placeOfPublication" : [ "Reinbek bei Hamburg" ],
   "publicationStatement" : [ "Reinbek bei Hamburg; Rowohlt-Taschenbuch-Verl.; 1998" ],
   "publisher" : [ "Rowohlt-Taschenbuch-Verl." ],
   "sameAs" : [ {
-    "@id" : "http://hub.culturegraph.org/resource/HBZ-HT015440386"
+    "id" : "http://hub.culturegraph.org/resource/HBZ-HT015440386"
   } ],
   "statementOfResponsibility" : [ "Ralf König" ],
   "subject" : [ {
-    "@id" : "http://d-nb.info/gnd/119411970",
+    "id" : "http://d-nb.info/gnd/119411970",
     "preferredName" : "König, Ralf",
     "preferredNameForThePerson" : "König, Ralf"
   }, {
-    "@id" : "http://d-nb.info/gnd/4145395-5",
-    "preferredName" : "Bildband",
-    "preferredNameForTheSubjectHeading" : "Bildband"
-  }, {
-    "@id" : "http://d-nb.info/gnd/4010427-8",
+    "id" : "http://d-nb.info/gnd/4010427-8",
     "preferredName" : "Comic",
     "preferredNameForTheSubjectHeading" : "Comic"
+  }, {
+    "id" : "http://d-nb.info/gnd/4145395-5",
+    "preferredName" : "Bildband",
+    "preferredNameForTheSubjectHeading" : "Bildband"
   } ],
   "subjectChain" : [ "König, Ralf | Comic | Bildband" ],
   "subjectLabel" : [ "Ansichtspostkarte (Formschlagwort)", "Konig, Ralf (1960-)", "Bildmaterial (Formschlagwort)", "Abbildungswerk", "Bildsammlung", "Illustrationswerk", "Bilddokumente", "Kēnigs, Ralfs (1960-)", "Photographien-Bildband", "Comic Strip", "Abbildungen (Formschlagwort)", "Bilder (Formschlagwort)", "Comicstrip", "Fotographien-Bildband", "Comic Strips", "King, Ralph (1960-)", "Ansichten (Formschlagwort)", "Bande Dessinée", "Comics", "Bildbände", "Bildatlas" ],
   "subjectOrder" : [ "http://d-nb.info/gnd/119411970, http://d-nb.info/gnd/4010427-8, http://d-nb.info/gnd/4145395-5" ],
   "title" : [ "Jago" ],
-  "type" : [ {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  }, {
-    "@id" : "http://purl.org/ontology/bibo/Book"
-  } ],
+  "type" : [ "http://purl.org/ontology/bibo/Book", "http://purl.org/dc/terms/BibliographicResource" ],
   "volume" : [ "22392" ]
 }

--- a/src/test/resources/output/json/01545/HT015455455.json
+++ b/src/test/resources/output/json/01545/HT015455455.json
@@ -1,95 +1,91 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/HT015455455",
   "contributorLabel" : [ "Pfundner, Martin" ],
   "contributorOrder" : [ "http://d-nb.info/gnd/124897274" ],
   "creator" : [ {
-    "@id" : "http://d-nb.info/gnd/124897274",
+    "id" : "http://d-nb.info/gnd/124897274",
     "preferredName" : "Pfundner, Martin",
     "preferredNameForThePerson" : "Pfundner, Martin"
   } ],
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/HT015455455/about",
-    "dateModified" : "20130930"
+    "dateModified" : "20130930",
+    "id" : "http://lobid.org/resource/HT015455455/about"
   } ],
   "description" : [ {
-    "@id" : "http://deposit.d-nb.de/cgi-bin/dokserv?id=2957975&prov=M&dok_var=1&dok_ext=htm"
+    "id" : "http://deposit.d-nb.de/cgi-bin/dokserv?id=2957975&prov=M&dok_var=1&dok_ext=htm"
   } ],
   "exemplar" : [ {
-    "@id" : "http://lobid.org/item/HT015455455:DE-107:208-316",
-    "callNumber" : "208-316",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT015455455:DE-107:208-316/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT015455455",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-107"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT015455455:DE-82:(1)043776",
     "callNumber" : "(1)043776",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT015455455:DE-82:(1)043776/about"
+      "id" : "http://lobid.org/item/HT015455455:DE-82:(1)043776/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT015455455",
+    "id" : "http://lobid.org/item/HT015455455:DE-82:(1)043776",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-82"
+      "id" : "http://lobid.org/organisation/DE-82"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "208-316",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT015455455:DE-107:208-316/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT015455455",
+    "id" : "http://lobid.org/item/HT015455455:DE-107:208-316",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-107"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   } ],
   "extent" : [ "291 S. : Ill., graph. Darst." ],
   "hbzId" : [ "HT015455455" ],
+  "id" : "http://lobid.org/resource/HT015455455",
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT015455455"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT015455455"
   } ],
   "isbn" : [ "9783205776390", "3205776399" ],
   "issued" : [ "2007" ],
   "language" : [ {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
   } ],
   "medium" : [ {
-    "@id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
+    "id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
   } ],
   "otherTitleInformation" : [ "Rivalen bis zur Fusion ; die frühen Jahre des Ferdinand Porsche" ],
   "placeOfPublication" : [ "Wien ; Köln ; Weimar" ],
   "publicationStatement" : [ "Wien ; Köln ; Weimar; 2007" ],
   "sameAs" : [ {
-    "@id" : "http://hub.culturegraph.org/resource/HBZ-HT015455455"
+    "id" : "http://hub.culturegraph.org/resource/HBZ-HT015455455"
   } ],
   "statementOfResponsibility" : [ "Martin Pfundner" ],
   "subject" : [ {
-    "@id" : "http://d-nb.info/gnd/4073757-3",
+    "id" : "http://d-nb.info/gnd/4073757-3",
     "preferredName" : "Kraftfahrzeug",
     "preferredNameForTheSubjectHeading" : "Kraftfahrzeug"
   }, {
-    "@id" : "http://d-nb.info/gnd/4443675-0",
+    "id" : "http://d-nb.info/gnd/4443675-0",
     "preferredName" : "Daimler, Marke",
     "preferredNameForTheSubjectHeading" : "Daimler, Marke"
   }, {
-    "@id" : "http://d-nb.info/gnd/2101246-5",
+    "id" : "http://d-nb.info/gnd/2101246-5",
     "preferredName" : "Austro-Daimler-Puchwerke",
     "preferredNameForTheCorporateBody" : "Austro-Daimler-Puchwerke"
   }, {
-    "@id" : "http://dewey.info/class/330/"
-  }, {
-    "@id" : "http://d-nb.info/gnd/4576855-9",
-    "preferredName" : "Steyr, Marke",
-    "preferredNameForTheSubjectHeading" : "Steyr, Marke"
-  }, {
-    "@id" : "http://d-nb.info/gnd/4207786-2",
+    "id" : "http://d-nb.info/gnd/4207786-2",
     "preferredName" : "Steyr-Daimler-Puch AG",
     "preferredNameForTheCorporateBody" : "Steyr-Daimler-Puch AG"
   }, {
-    "@id" : "http://d-nb.info/gnd/118595881",
+    "id" : "http://dewey.info/class/330/"
+  }, {
+    "id" : "http://d-nb.info/gnd/4576855-9",
+    "preferredName" : "Steyr, Marke",
+    "preferredNameForTheSubjectHeading" : "Steyr, Marke"
+  }, {
+    "id" : "http://d-nb.info/gnd/118595881",
     "preferredName" : "Porsche, Ferdinand",
     "preferredNameForThePerson" : "Porsche, Ferdinand"
   }, {
-    "@id" : "http://d-nb.info/gnd/4003988-2",
+    "id" : "http://d-nb.info/gnd/4003988-2",
     "preferredName" : "Automobilsport",
     "preferredNameForTheSubjectHeading" : "Automobilsport"
   } ],
@@ -97,9 +93,5 @@
   "subjectLabel" : [ "Automobilrennsport", "Steyr-Daimler-Puch-AG", "Austro-Daimler-Puchwerke (Wiener Neustadt)", "SDP AG", "Daimler-Puchwerke, Austro-", "Österreichische Daimler-Motoren-Commanditgesellschaft Bierenz, Fischer und Co. (Wiener Neustadt)", "Autorennsport", "Motorfahrzeug", "Daimler Company (Marke)", "Kraftfahrzeuge", "Kfz" ],
   "subjectOrder" : [ "http://d-nb.info/gnd/2101246-5, http://d-nb.info/gnd/118595881, http://d-nb.info/gnd/4207786-2, Geschichte", "http://d-nb.info/gnd/2101246-5, http://d-nb.info/gnd/4003988-2, http://d-nb.info/gnd/4207786-2, Geschichte", "http://d-nb.info/gnd/4443675-0, http://d-nb.info/gnd/4073757-3, Geschichte 1918-1940, Verzeichnis", "http://d-nb.info/gnd/4576855-9, http://d-nb.info/gnd/4073757-3, Geschichte 1920-1945, Verzeichnis" ],
   "title" : [ "Austro-Daimler und Steyr" ],
-  "type" : [ {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  }, {
-    "@id" : "http://purl.org/ontology/bibo/Book"
-  } ]
+  "type" : [ "http://purl.org/ontology/bibo/Book", "http://purl.org/dc/terms/BibliographicResource" ]
 }

--- a/src/test/resources/output/json/01586/HT015865114.json
+++ b/src/test/resources/output/json/01586/HT015865114.json
@@ -1,99 +1,89 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/HT015865114",
   "contributor" : [ {
-    "@id" : "http://d-nb.info/gnd/105667129",
+    "id" : "http://d-nb.info/gnd/105667129",
     "preferredName" : "Weber, Jürgen",
     "preferredNameForThePerson" : "Weber, Jürgen"
   } ],
   "contributorLabel" : [ "Weber, Jürgen" ],
   "contributorOrder" : [ "http://d-nb.info/gnd/105667129" ],
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/HT015865114/about",
     "dateCreated" : "20090317",
-    "dateModified" : "20090318"
+    "dateModified" : "20090318",
+    "id" : "http://lobid.org/resource/HT015865114/about"
   } ],
   "exemplar" : [ {
-    "@id" : "http://lobid.org/item/HT015865114:DE-6-290:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT015865114:DE-6-290:/about"
+      "id" : "http://lobid.org/item/HT015865114:DE-929:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT015865114",
+    "id" : "http://lobid.org/item/HT015865114:DE-929:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-6-290"
+      "id" : "http://lobid.org/organisation/DE-929"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT015865114:DE-929:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT015865114:DE-929:/about"
+      "id" : "http://lobid.org/item/HT015865114:DE-Lan1:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT015865114",
+    "id" : "http://lobid.org/item/HT015865114:DE-Lan1:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-929"
+      "id" : "http://lobid.org/organisation/DE-Lan1"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT015865114:DE-294-11:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT015865114:DE-294-11:/about"
+      "id" : "http://lobid.org/item/HT015865114:DE-6-290:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT015865114",
+    "id" : "http://lobid.org/item/HT015865114:DE-6-290:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-294-11"
+      "id" : "http://lobid.org/organisation/DE-6-290"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT015865114:DE-Lan1:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT015865114:DE-Lan1:/about"
+      "id" : "http://lobid.org/item/HT015865114:DE-294-11:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT015865114",
+    "id" : "http://lobid.org/item/HT015865114:DE-294-11:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Lan1"
+      "id" : "http://lobid.org/organisation/DE-294-11"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   } ],
   "frequency" : [ "Erschienen: Schüler- und Lehrerbd." ],
   "hbzId" : [ "HT015865114" ],
+  "id" : "http://lobid.org/resource/HT015865114",
   "inSeries" : [ {
     "series" : [ {
-      "@id" : "http://lobid.org/resource/HT013370531"
+      "id" : "http://lobid.org/resource/HT013370531"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/lobid/lv#SeriesRelation"
-    } ]
+    "type" : [ "http://purl.org/lobid/lv#SeriesRelation" ]
   } ],
   "isPartOf" : [ {
-    "@id" : "http://lobid.org/resource/HT013370531"
+    "id" : "http://lobid.org/resource/HT013370531"
   } ],
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT015865114"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT015865114"
   } ],
   "issued" : [ "2003 - " ],
   "language" : [ {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
   } ],
   "medium" : [ {
-    "@id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
+    "id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
   } ],
   "otherTitleInformation" : [ "die Welt nach 1945" ],
   "placeOfPublication" : [ "Bamberg" ],
   "publicationStatement" : [ "Bamberg; Buchner; 2003" ],
   "publisher" : [ "Buchner" ],
   "sameAs" : [ {
-    "@id" : "http://hub.culturegraph.org/resource/HBZ-HT015865114"
+    "id" : "http://hub.culturegraph.org/resource/HBZ-HT015865114"
   } ],
   "subject" : [ {
-    "@id" : "http://d-nb.info/gnd/4020533-2",
+    "id" : "http://d-nb.info/gnd/4020533-2",
     "preferredName" : "Geschichtsunterricht",
     "preferredNameForTheSubjectHeading" : "Geschichtsunterricht"
   } ],
@@ -102,13 +92,5 @@
   "subjectOrder" : [ "http://d-nb.info/gnd/4020533-2, Schulbuch" ],
   "title" : [ "Von der Teilung zur Einheit" ],
   "titleKeyword" : [ "Schulbuch Buchner" ],
-  "type" : [ {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  }, {
-    "@id" : "http://purl.org/lobid/lv#Schoolbook"
-  }, {
-    "@id" : "http://purl.org/ontology/bibo/Book"
-  }, {
-    "@id" : "http://purl.org/ontology/bibo/MultiVolumeBook"
-  } ]
+  "type" : [ "http://purl.org/ontology/bibo/Book", "http://purl.org/ontology/bibo/MultiVolumeBook", "http://purl.org/dc/terms/BibliographicResource", "http://purl.org/lobid/lv#Schoolbook" ]
 }

--- a/src/test/resources/output/json/01589/HT015891797.json
+++ b/src/test/resources/output/json/01589/HT015891797.json
@@ -1,196 +1,174 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/HT015891797",
   "collectedBy" : [ {
-    "@id" : "http://lobid.org/resource/NWBib"
+    "id" : "http://lobid.org/resource/NWBib"
   } ],
   "contributor" : [ {
-    "@id" : "http://d-nb.info/gnd/109702662",
+    "id" : "http://d-nb.info/gnd/109702662",
     "preferredName" : "Mensing, Hans Peter",
     "preferredNameForThePerson" : "Mensing, Hans Peter"
   } ],
   "contributorLabel" : [ "Adenauer, Konrad", "Mensing, Hans Peter", "Adenauer, ...", "Adenauer, Konrad Hermann Joseph" ],
   "contributorOrder" : [ "http://d-nb.info/gnd/11850066X | http://d-nb.info/gnd/109702662" ],
   "creator" : [ {
-    "@id" : "http://d-nb.info/gnd/11850066X",
+    "id" : "http://d-nb.info/gnd/11850066X",
     "preferredName" : "Adenauer, Konrad",
     "preferredNameForThePerson" : "Adenauer, Konrad"
   } ],
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/HT015891797/about",
     "dateCreated" : "20090407",
-    "dateModified" : "20090817"
+    "dateModified" : "20090817",
+    "id" : "http://lobid.org/resource/HT015891797/about"
   } ],
   "exemplar" : [ {
-    "@id" : "http://lobid.org/item/HT015891797:DE-38:4E1244-18",
-    "callNumber" : "4E1244-18",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT015891797:DE-38:4E1244-18/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT015891797",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-38"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT015891797:DE-465:LRKA1168-1,10,2",
-    "callNumber" : "LRKA1168-1,10,2",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT015891797:DE-465:LRKA1168-1,10,2/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT015891797",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-465"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT015891797:DE-468:OTSA1188-2",
-    "callNumber" : "OTSA1188-2",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT015891797:DE-468:OTSA1188-2/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT015891797",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-468"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT015891797:DE-6:3F%2080610-2",
-    "callNumber" : "3F 80610-2",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT015891797:DE-6:3F%2080610-2/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT015891797",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-6"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT015891797:DE-107:9.1191%2F10,2",
-    "callNumber" : "9.1191/10,2",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT015891797:DE-107:9.1191%2F10,2/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT015891797",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-107"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT015891797:DE-121:09%20A%20756",
     "callNumber" : "09 A 756",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT015891797:DE-121:09%20A%20756/about"
+      "id" : "http://lobid.org/item/HT015891797:DE-121:09%20A%20756/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT015891797",
+    "id" : "http://lobid.org/item/HT015891797:DE-121:09%20A%20756",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-121"
+      "id" : "http://lobid.org/organisation/DE-121"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT015891797:DE-51:LRKA%20101-S,4,2",
-    "callNumber" : "LRKA 101-S,4,2",
+    "callNumber" : "3F 80610-2",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT015891797:DE-51:LRKA%20101-S,4,2/about"
+      "id" : "http://lobid.org/item/HT015891797:DE-6:3F%2080610-2/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT015891797",
+    "id" : "http://lobid.org/item/HT015891797:DE-6:3F%2080610-2",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-51"
+      "id" : "http://lobid.org/organisation/DE-6"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT015891797:DE-929:2009%2F1681:2",
-    "callNumber" : "2009/1681:2",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT015891797:DE-929:2009%2F1681:2/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT015891797",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-929"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT015891797:DE-61:hisi430.a232(2)",
-    "callNumber" : "hisi430.a232(2)",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT015891797:DE-61:hisi430.a232(2)/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT015891797",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-61"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT015891797:DE-Sie5:82%20=%204385",
     "callNumber" : "82 = 4385",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT015891797:DE-Sie5:82%20=%204385/about"
+      "id" : "http://lobid.org/item/HT015891797:DE-Sie5:82%20=%204385/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT015891797",
+    "id" : "http://lobid.org/item/HT015891797:DE-Sie5:82%20=%204385",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Sie5"
+      "id" : "http://lobid.org/organisation/DE-Sie5"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT015891797:DE-385:AL.A%2Fsb21613L-2",
+    "callNumber" : "LRKA1168-1,10,2",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT015891797:DE-465:LRKA1168-1,10,2/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT015891797",
+    "id" : "http://lobid.org/item/HT015891797:DE-465:LRKA1168-1,10,2",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-465"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "9.1191/10,2",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT015891797:DE-107:9.1191%2F10,2/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT015891797",
+    "id" : "http://lobid.org/item/HT015891797:DE-107:9.1191%2F10,2",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-107"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "OTSA1188-2",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT015891797:DE-468:OTSA1188-2/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT015891797",
+    "id" : "http://lobid.org/item/HT015891797:DE-468:OTSA1188-2",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-468"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
     "callNumber" : "AL.A/sb21613L-2",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT015891797:DE-385:AL.A%2Fsb21613L-2/about"
+      "id" : "http://lobid.org/item/HT015891797:DE-385:AL.A%2Fsb21613L-2/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT015891797",
+    "id" : "http://lobid.org/item/HT015891797:DE-385:AL.A%2Fsb21613L-2",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-385"
+      "id" : "http://lobid.org/organisation/DE-385"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "4E1244-18",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT015891797:DE-38:4E1244-18/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT015891797",
+    "id" : "http://lobid.org/item/HT015891797:DE-38:4E1244-18",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-38"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "LRKA 101-S,4,2",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT015891797:DE-51:LRKA%20101-S,4,2/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT015891797",
+    "id" : "http://lobid.org/item/HT015891797:DE-51:LRKA%20101-S,4,2",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-51"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "hisi430.a232(2)",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT015891797:DE-61:hisi430.a232(2)/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT015891797",
+    "id" : "http://lobid.org/item/HT015891797:DE-61:hisi430.a232(2)",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-61"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "2009/1681:2",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT015891797:DE-929:2009%2F1681:2/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT015891797",
+    "id" : "http://lobid.org/item/HT015891797:DE-929:2009%2F1681:2",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-929"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   } ],
   "extent" : [ "670 S. : Ill." ],
   "hbzId" : [ "HT015891797" ],
+  "id" : "http://lobid.org/resource/HT015891797",
   "isPartOf" : [ {
-    "@id" : "http://lobid.org/resource/HT002786685"
+    "id" : "http://lobid.org/resource/HT002786685"
   }, {
-    "@id" : "http://lobid.org/resource/HT015845132"
+    "id" : "http://lobid.org/resource/HT015845132"
   } ],
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT015891797"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT015891797"
   } ],
   "issued" : [ "2009" ],
   "language" : [ {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
   } ],
   "medium" : [ {
-    "@id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
+    "id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
   } ],
   "placeOfPublication" : [ "Paderborn [u.a.]" ],
   "publicationStatement" : [ "Paderborn [u.a.]; Schöningh; 2009" ],
   "publisher" : [ "Schöningh" ],
   "sameAs" : [ {
-    "@id" : "http://hub.culturegraph.org/resource/HBZ-HT015891797"
+    "id" : "http://hub.culturegraph.org/resource/HBZ-HT015891797"
   } ],
   "statementOfResponsibility" : [ "Adenauer. Bearb. von Hans Peter Mensing" ],
   "subject" : [ {
-    "@id" : "http://d-nb.info/gnd/11850066X",
+    "id" : "http://d-nb.info/gnd/11850066X",
     "preferredName" : "Adenauer, Konrad",
     "preferredNameForThePerson" : "Adenauer, Konrad"
   } ],
@@ -198,19 +176,13 @@
   "subjectLabel" : [ "Adenauer, Konrad Hermann Joseph (1876-1967)", "Adenauer, ... (1876-1967)" ],
   "subjectOrder" : [ "http://d-nb.info/gnd/11850066X, Geschichte 1963-1967, Quelle" ],
   "title" : [ "Die letzten Lebensjahre, 1963 - 1967, 2: September 1965 - April 1967" ],
-  "type" : [ {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  }, {
-    "@id" : "http://purl.org/ontology/bibo/Book"
-  } ],
+  "type" : [ "http://purl.org/ontology/bibo/Book", "http://purl.org/dc/terms/BibliographicResource" ],
   "volume" : [ "2" ],
   "volumeIn" : [ {
     "multiVolumeWork" : [ {
-      "@id" : "http://lobid.org/resource/HT015845132"
+      "id" : "http://lobid.org/resource/HT015845132"
     } ],
     "numbering" : "2",
-    "type" : [ {
-      "@id" : "http://purl.org/lobid/lv#MultiVolumeWorkRelation"
-    } ]
+    "type" : [ "http://purl.org/lobid/lv#MultiVolumeWorkRelation" ]
   } ]
 }

--- a/src/test/resources/output/json/01589/HT015894164.json
+++ b/src/test/resources/output/json/01589/HT015894164.json
@@ -1,350 +1,296 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/HT015894164",
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/HT015894164/about",
     "dateCreated" : "20090408",
-    "dateModified" : "20120815"
+    "dateModified" : "20120815",
+    "id" : "http://lobid.org/resource/HT015894164/about"
   } ],
   "doi" : [ "10.1787/9789264273085-fr" ],
   "exemplar" : [ {
-    "@id" : "http://lobid.org/item/HT015894164:DE-464:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT015894164:DE-464:/about"
+      "id" : "http://lobid.org/item/HT015894164:DE-468:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT015894164",
+    "id" : "http://lobid.org/item/HT015894164:DE-468:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-464"
+      "id" : "http://lobid.org/organisation/DE-468"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT015894164:DE-Hag4:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT015894164:DE-Hag4:/about"
+      "id" : "http://lobid.org/item/HT015894164:DE-Bm40:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT015894164",
+    "id" : "http://lobid.org/item/HT015894164:DE-Bm40:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Hag4"
+      "id" : "http://lobid.org/organisation/DE-Bm40"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT015894164:DE-468:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT015894164:DE-468:/about"
+      "id" : "http://lobid.org/item/HT015894164:DE-5:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT015894164",
+    "id" : "http://lobid.org/item/HT015894164:DE-5:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-468"
+      "id" : "http://lobid.org/organisation/DE-5"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT015894164:DE-1383a:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT015894164:DE-1383a:/about"
+      "id" : "http://lobid.org/item/HT015894164:DE-1383a:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT015894164",
+    "id" : "http://lobid.org/item/HT015894164:DE-1383a:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-1383a"
+      "id" : "http://lobid.org/organisation/DE-1383a"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT015894164:DE-361:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT015894164:DE-361:/about"
+      "id" : "http://lobid.org/item/HT015894164:DE-361:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT015894164",
+    "id" : "http://lobid.org/item/HT015894164:DE-361:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-361"
+      "id" : "http://lobid.org/organisation/DE-361"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT015894164:DE-294:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT015894164:DE-294:/about"
+      "id" : "http://lobid.org/item/HT015894164:DE-466:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT015894164",
+    "id" : "http://lobid.org/item/HT015894164:DE-466:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-294"
+      "id" : "http://lobid.org/organisation/DE-466"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT015894164:DE-832:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT015894164:DE-832:/about"
+      "id" : "http://lobid.org/item/HT015894164:DE-832:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT015894164",
+    "id" : "http://lobid.org/item/HT015894164:DE-832:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-832"
+      "id" : "http://lobid.org/organisation/DE-832"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT015894164:DE-829:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT015894164:DE-829:/about"
+      "id" : "http://lobid.org/item/HT015894164:DE-1393-BOT:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT015894164",
+    "id" : "http://lobid.org/item/HT015894164:DE-1393-BOT:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-829"
+      "id" : "http://lobid.org/organisation/DE-1393-BOT"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT015894164:DE-Due62:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT015894164:DE-Due62:/about"
+      "id" : "http://lobid.org/item/HT015894164:DE-385:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT015894164",
+    "id" : "http://lobid.org/item/HT015894164:DE-385:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Due62"
+      "id" : "http://lobid.org/organisation/DE-385"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT015894164:DE-466:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT015894164:DE-466:/about"
+      "id" : "http://lobid.org/item/HT015894164:DE-465:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT015894164",
+    "id" : "http://lobid.org/item/HT015894164:DE-465:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-466"
+      "id" : "http://lobid.org/organisation/DE-465"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT015894164:DE-708:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT015894164:DE-708:/about"
+      "id" : "http://lobid.org/item/HT015894164:DE-708:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT015894164",
+    "id" : "http://lobid.org/item/HT015894164:DE-708:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-708"
+      "id" : "http://lobid.org/organisation/DE-708"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT015894164:DE-5:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT015894164:DE-5:/about"
+      "id" : "http://lobid.org/item/HT015894164:DE-294:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT015894164",
+    "id" : "http://lobid.org/item/HT015894164:DE-294:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-5"
+      "id" : "http://lobid.org/organisation/DE-294"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT015894164:DE-385:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT015894164:DE-385:/about"
+      "id" : "http://lobid.org/item/HT015894164:DE-1393:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT015894164",
+    "id" : "http://lobid.org/item/HT015894164:DE-1393:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-385"
+      "id" : "http://lobid.org/organisation/DE-1393"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT015894164:DE-465:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT015894164:DE-465:/about"
+      "id" : "http://lobid.org/item/HT015894164:DE-Due62:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT015894164",
+    "id" : "http://lobid.org/item/HT015894164:DE-Due62:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-465"
+      "id" : "http://lobid.org/organisation/DE-Due62"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT015894164:DE-1383:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT015894164:DE-1383:/about"
+      "id" : "http://lobid.org/item/HT015894164:DE-829:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT015894164",
+    "id" : "http://lobid.org/item/HT015894164:DE-829:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-1383"
+      "id" : "http://lobid.org/organisation/DE-829"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT015894164:DE-1044:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT015894164:DE-1044:/about"
+      "id" : "http://lobid.org/item/HT015894164:DE-1383:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT015894164",
+    "id" : "http://lobid.org/item/HT015894164:DE-1383:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-1044"
+      "id" : "http://lobid.org/organisation/DE-1383"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT015894164:DE-1393:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT015894164:DE-1393:/about"
+      "id" : "http://lobid.org/item/HT015894164:DE-1044:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT015894164",
+    "id" : "http://lobid.org/item/HT015894164:DE-1044:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-1393"
+      "id" : "http://lobid.org/organisation/DE-1044"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT015894164:DE-Tr5:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT015894164:DE-Tr5:/about"
+      "id" : "http://lobid.org/item/HT015894164:DE-38:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT015894164",
+    "id" : "http://lobid.org/item/HT015894164:DE-38:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Tr5"
+      "id" : "http://lobid.org/organisation/DE-38"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT015894164:DE-1393-BOT:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT015894164:DE-1393-BOT:/about"
+      "id" : "http://lobid.org/item/HT015894164:DE-6:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT015894164",
+    "id" : "http://lobid.org/item/HT015894164:DE-6:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-1393-BOT"
+      "id" : "http://lobid.org/organisation/DE-6"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT015894164:DE-290:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT015894164:DE-290:/about"
+      "id" : "http://lobid.org/item/HT015894164:DE-82:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT015894164",
+    "id" : "http://lobid.org/item/HT015894164:DE-82:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-290"
+      "id" : "http://lobid.org/organisation/DE-82"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT015894164:DE-38:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT015894164:DE-38:/about"
+      "id" : "http://lobid.org/item/HT015894164:DE-Tr5:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT015894164",
+    "id" : "http://lobid.org/item/HT015894164:DE-Tr5:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-38"
+      "id" : "http://lobid.org/organisation/DE-Tr5"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT015894164:DE-836:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT015894164:DE-836:/about"
+      "id" : "http://lobid.org/item/HT015894164:DE-836:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT015894164",
+    "id" : "http://lobid.org/item/HT015894164:DE-836:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-836"
+      "id" : "http://lobid.org/organisation/DE-836"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT015894164:DE-6:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT015894164:DE-6:/about"
+      "id" : "http://lobid.org/item/HT015894164:DE-290:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT015894164",
+    "id" : "http://lobid.org/item/HT015894164:DE-290:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-6"
+      "id" : "http://lobid.org/organisation/DE-290"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT015894164:DE-82:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT015894164:DE-82:/about"
+      "id" : "http://lobid.org/item/HT015894164:DE-464:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT015894164",
+    "id" : "http://lobid.org/item/HT015894164:DE-464:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-82"
+      "id" : "http://lobid.org/organisation/DE-464"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT015894164:DE-Bm40:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT015894164:DE-Bm40:/about"
+      "id" : "http://lobid.org/item/HT015894164:DE-Hag4:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT015894164",
+    "id" : "http://lobid.org/item/HT015894164:DE-Hag4:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Bm40"
+      "id" : "http://lobid.org/organisation/DE-Hag4"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   } ],
   "extent" : [ "88 p." ],
   "fulltextOnline" : [ {
-    "@id" : "http://dx.doi.org/10.1787/9789264273085-fr"
+    "id" : "http://dx.doi.org/10.1787/9789264273085-fr"
   } ],
   "hasVersion" : [ {
-    "@id" : "http://dx.doi.org/10.1787/9789264273085-fr"
+    "id" : "http://dx.doi.org/10.1787/9789264273085-fr"
   } ],
   "hbzId" : [ "HT015894164" ],
+  "id" : "http://lobid.org/resource/HT015894164",
   "isPartOfName" : [ "Examens en matière de coopération pour le développement" ],
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT015894164"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT015894164"
   } ],
   "isbn" : [ "9789264273085" ],
   "issued" : [ "1999" ],
   "language" : [ {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/fra"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/fra"
   } ],
   "medium" : [ {
-    "@id" : "http://rdvocab.info/termList/RDACarrierType/1018"
+    "id" : "http://rdvocab.info/termList/RDACarrierType/1018"
   }, {
-    "@id" : "http://rdvocab.info/termList/RDACarrierType/1010"
+    "id" : "http://rdvocab.info/termList/RDACarrierType/1010"
   } ],
   "placeOfPublication" : [ "Paris" ],
   "publicationStatement" : [ "Paris; OECD Publishing; 1999" ],
   "publisher" : [ "OECD Publishing" ],
   "sameAs" : [ {
-    "@id" : "http://hub.culturegraph.org/resource/HBZ-HT015894164"
+    "id" : "http://hub.culturegraph.org/resource/HBZ-HT015894164"
   } ],
   "similar" : [ {
-    "@id" : "http://dx.doi.org/10.1787/9789264273085-fr"
+    "id" : "http://dx.doi.org/10.1787/9789264273085-fr"
   } ],
   "statementOfResponsibility" : [ "Organisation de coopération et de développement économiques" ],
   "title" : [ "Examens en matière de coopération pour le développement : Danemark 1999" ],
-  "type" : [ {
-    "@id" : "http://purl.org/lobid/lv#Miscellaneous"
-  }, {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  } ],
+  "type" : [ "http://purl.org/dc/terms/BibliographicResource", "http://purl.org/lobid/lv#Miscellaneous" ],
   "volume" : [ "no.33" ]
 }

--- a/src/test/resources/output/json/01613/HT016135351.json
+++ b/src/test/resources/output/json/01613/HT016135351.json
@@ -1,49 +1,47 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/HT016135351",
   "collectedBy" : [ {
-    "@id" : "http://lobid.org/resource/NWBib"
+    "id" : "http://lobid.org/resource/NWBib"
   } ],
   "contributorLabel" : [ "Buchmann, Helmut" ],
   "contributorOrder" : [ "http://d-nb.info/gnd/186931808" ],
   "coverage" : [ "Harsewinkel-Marienfeld" ],
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/HT016135351/about",
     "dateCreated" : "20091118",
-    "dateModified" : "20091210"
+    "dateModified" : "20091210",
+    "id" : "http://lobid.org/resource/HT016135351/about"
   } ],
   "exemplar" : [ {
-    "@id" : "http://lobid.org/item/HT016135351:DE-6:2C%208876",
     "callNumber" : "2C 8876",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT016135351:DE-6:2C%208876/about"
+      "id" : "http://lobid.org/item/HT016135351:DE-6:2C%208876/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT016135351",
+    "id" : "http://lobid.org/item/HT016135351:DE-6:2C%208876",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-6"
+      "id" : "http://lobid.org/organisation/DE-6"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   } ],
   "extent" : [ "32 gez. S. : überw. Ill." ],
   "hbzId" : [ "HT016135351" ],
+  "id" : "http://lobid.org/resource/HT016135351",
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT016135351"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT016135351"
   } ],
   "issued" : [ "2006" ],
   "language" : [ {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
   } ],
   "medium" : [ {
-    "@id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
+    "id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
   } ],
   "nwbibsubject" : [ {
-    "@id" : "http://purl.org/lobid/nwbib#s708029"
+    "id" : "http://purl.org/lobid/nwbib#s708029"
   } ],
   "otherTitleInformation" : [ "Zeitzeuge und Kleinod in Harsewinkel" ],
   "photographer" : [ {
-    "@id" : "http://d-nb.info/gnd/186931808",
+    "id" : "http://d-nb.info/gnd/186931808",
     "preferredName" : "Buchmann, Helmut",
     "preferredNameForThePerson" : "Buchmann, Helmut"
   } ],
@@ -51,11 +49,11 @@
   "publicationStatement" : [ "Marienfeld; Selbstverl.; 2006" ],
   "publisher" : [ "Selbstverl." ],
   "sameAs" : [ {
-    "@id" : "http://hub.culturegraph.org/resource/HBZ-HT016135351"
+    "id" : "http://hub.culturegraph.org/resource/HBZ-HT016135351"
   } ],
   "statementOfResponsibility" : [ "[Hemut Buchmann" ],
   "subject" : [ {
-    "@id" : "http://d-nb.info/gnd/7684863-2",
+    "id" : "http://d-nb.info/gnd/7684863-2",
     "preferredName" : "Lutter-Wassermühle Roberg, Harsewinkel",
     "preferredNameForThePlaceOrGeographicName" : "Lutter-Wassermühle Roberg"
   } ],
@@ -63,9 +61,5 @@
   "subjectLabel" : [ "Lutter-Wassermühle Roberg (Harsewinkel-Marienfeld)", "Mühle Roberg (Harsewinkel)", "Kornmühle Roberg (Harsewinkel)" ],
   "subjectOrder" : [ "http://d-nb.info/gnd/7684863-2, Bildband" ],
   "title" : [ "Lutter-Wassermühle Roberg" ],
-  "type" : [ {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  }, {
-    "@id" : "http://purl.org/ontology/bibo/Book"
-  } ]
+  "type" : [ "http://purl.org/ontology/bibo/Book", "http://purl.org/dc/terms/BibliographicResource" ]
 }

--- a/src/test/resources/output/json/01638/HT016382441.json
+++ b/src/test/resources/output/json/01638/HT016382441.json
@@ -1,335 +1,289 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/HT016382441",
   "alternativeTitle" : [ "Linux for dummies <dt.>" ],
   "contributorLabel" : [ "Blum, Richard Kenneth", "Blum, Richard" ],
   "contributorOrder" : [ "http://d-nb.info/gnd/14320713X" ],
   "creator" : [ {
-    "@id" : "http://d-nb.info/gnd/14320713X",
+    "id" : "http://d-nb.info/gnd/14320713X",
     "preferredName" : "Blum, Richard",
     "preferredNameForThePerson" : "Blum, Richard"
   } ],
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/HT016382441/about",
     "dateCreated" : "20100607",
-    "dateModified" : "20110309"
+    "dateModified" : "20110309",
+    "id" : "http://lobid.org/resource/HT016382441/about"
   } ],
   "description" : [ {
-    "@id" : "http://deposit.d-nb.de/cgi-bin/dokserv?id=3474380&prov=M&dok_var=1&dok_ext=htm"
+    "id" : "http://deposit.d-nb.de/cgi-bin/dokserv?id=3474380&prov=M&dok_var=1&dok_ext=htm"
   } ],
   "edition" : [ "1. Aufl." ],
   "exemplar" : [ {
-    "@id" : "http://lobid.org/item/HT016382441:DE-61:nc%2F18910",
-    "callNumber" : "nc/18910",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT016382441:DE-61:nc%2F18910/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT016382441",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-61"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT016382441:DE-929:2011%2F591",
-    "callNumber" : "2011/591",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT016382441:DE-929:2011%2F591/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT016382441",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-929"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT016382441:DE-107:112-2195",
-    "callNumber" : "112-2195",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT016382441:DE-107:112-2195/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT016382441",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-107"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT016382441:DE-1393:00%2FTWR6",
-    "callNumber" : "00/TWR6",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT016382441:DE-1393:00%2FTWR6/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT016382441",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-1393"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT016382441:DE-6:033%204370%233",
-    "callNumber" : "033 4370#3",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT016382441:DE-6:033%204370%233/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT016382441",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-6"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT016382441:DE-1044:11%20=%20TWR5408%2B2",
     "callNumber" : "11 = TWR5408+2",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT016382441:DE-1044:11%20=%20TWR5408%2B2/about"
+      "id" : "http://lobid.org/item/HT016382441:DE-1044:11%20=%20TWR5408%2B2/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT016382441",
+    "id" : "http://lobid.org/item/HT016382441:DE-1044:11%20=%20TWR5408%2B2",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-1044"
+      "id" : "http://lobid.org/organisation/DE-1044"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT016382441:DE-1044:21%20=%20TWR5408%2B5",
-    "callNumber" : "21 = TWR5408+5",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT016382441:DE-1044:21%20=%20TWR5408%2B5/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT016382441",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-1044"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT016382441:DE-467:51TWRF4584",
     "callNumber" : "51TWRF4584",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT016382441:DE-467:51TWRF4584/about"
+      "id" : "http://lobid.org/item/HT016382441:DE-467:51TWRF4584/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT016382441",
+    "id" : "http://lobid.org/item/HT016382441:DE-467:51TWRF4584",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-467"
+      "id" : "http://lobid.org/organisation/DE-467"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT016382441:DE-467:80TWRF4584-DVD",
-    "callNumber" : "80TWRF4584-DVD",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT016382441:DE-467:80TWRF4584-DVD/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT016382441",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-467"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT016382441:DE-51:TWR%20644",
-    "callNumber" : "TWR 644",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT016382441:DE-51:TWR%20644/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT016382441",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-51"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT016382441:DE-1044:11%20=%20TWR5408%2B4",
-    "callNumber" : "11 = TWR5408+4",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT016382441:DE-1044:11%20=%20TWR5408%2B4/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT016382441",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-1044"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT016382441:DE-1044:11%20=%20TWR5408%2B1",
-    "callNumber" : "11 = TWR5408+1",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT016382441:DE-1044:11%20=%20TWR5408%2B1/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT016382441",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-1044"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT016382441:DE-A96:61%20TWR%201197",
-    "callNumber" : "61 TWR 1197",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT016382441:DE-A96:61%20TWR%201197/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT016382441",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-A96"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT016382441:DE-Dm13:TWR%201053",
-    "callNumber" : "TWR 1053",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT016382441:DE-Dm13:TWR%201053/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT016382441",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Dm13"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT016382441:DE-6:033%204370",
-    "callNumber" : "033 4370",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT016382441:DE-6:033%204370/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT016382441",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-6"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT016382441:DE-361:HI088.88-4332104",
-    "callNumber" : "HI088.88-4332104",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT016382441:DE-361:HI088.88-4332104/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT016382441",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-361"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT016382441:DE-361:HK360=L760%20B658",
-    "callNumber" : "HK360=L760 B658",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT016382441:DE-361:HK360=L760%20B658/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT016382441",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-361"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT016382441:DE-1044:11%20=%20TWR5408",
-    "callNumber" : "11 = TWR5408",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT016382441:DE-1044:11%20=%20TWR5408/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT016382441",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-1044"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT016382441:DE-1044:11%20=%20TWR5408%2B3",
-    "callNumber" : "11 = TWR5408+3",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT016382441:DE-1044:11%20=%20TWR5408%2B3/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT016382441",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-1044"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT016382441:DE-6:033%204370%232",
     "callNumber" : "033 4370#2",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT016382441:DE-6:033%204370%232/about"
+      "id" : "http://lobid.org/item/HT016382441:DE-6:033%204370%232/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT016382441",
+    "id" : "http://lobid.org/item/HT016382441:DE-6:033%204370%232",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-6"
+      "id" : "http://lobid.org/organisation/DE-6"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT016382441:DE-Hag4-2:M%2FP-Tgn%20162",
+    "callNumber" : "11 = TWR5408+3",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT016382441:DE-1044:11%20=%20TWR5408%2B3/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT016382441",
+    "id" : "http://lobid.org/item/HT016382441:DE-1044:11%20=%20TWR5408%2B3",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-1044"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "nc/18910",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT016382441:DE-61:nc%2F18910/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT016382441",
+    "id" : "http://lobid.org/item/HT016382441:DE-61:nc%2F18910",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-61"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "TWR 644",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT016382441:DE-51:TWR%20644/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT016382441",
+    "id" : "http://lobid.org/item/HT016382441:DE-51:TWR%20644",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-51"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "2011/591",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT016382441:DE-929:2011%2F591/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT016382441",
+    "id" : "http://lobid.org/item/HT016382441:DE-929:2011%2F591",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-929"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "11 = TWR5408+1",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT016382441:DE-1044:11%20=%20TWR5408%2B1/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT016382441",
+    "id" : "http://lobid.org/item/HT016382441:DE-1044:11%20=%20TWR5408%2B1",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-1044"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "11 = TWR5408+4",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT016382441:DE-1044:11%20=%20TWR5408%2B4/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT016382441",
+    "id" : "http://lobid.org/item/HT016382441:DE-1044:11%20=%20TWR5408%2B4",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-1044"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "00/TWR6",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT016382441:DE-1393:00%2FTWR6/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT016382441",
+    "id" : "http://lobid.org/item/HT016382441:DE-1393:00%2FTWR6",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-1393"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "033 4370#3",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT016382441:DE-6:033%204370%233/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT016382441",
+    "id" : "http://lobid.org/item/HT016382441:DE-6:033%204370%233",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-6"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "21 = TWR5408+5",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT016382441:DE-1044:21%20=%20TWR5408%2B5/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT016382441",
+    "id" : "http://lobid.org/item/HT016382441:DE-1044:21%20=%20TWR5408%2B5",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-1044"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "11 = TWR5408",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT016382441:DE-1044:11%20=%20TWR5408/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT016382441",
+    "id" : "http://lobid.org/item/HT016382441:DE-1044:11%20=%20TWR5408",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-1044"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
     "callNumber" : "M/P-Tgn 162",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT016382441:DE-Hag4-2:M%2FP-Tgn%20162/about"
+      "id" : "http://lobid.org/item/HT016382441:DE-Hag4-2:M%2FP-Tgn%20162/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT016382441",
+    "id" : "http://lobid.org/item/HT016382441:DE-Hag4-2:M%2FP-Tgn%20162",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Hag4-2"
+      "id" : "http://lobid.org/organisation/DE-Hag4-2"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "TWR 1053",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT016382441:DE-Dm13:TWR%201053/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT016382441",
+    "id" : "http://lobid.org/item/HT016382441:DE-Dm13:TWR%201053",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-Dm13"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "80TWRF4584-DVD",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT016382441:DE-467:80TWRF4584-DVD/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT016382441",
+    "id" : "http://lobid.org/item/HT016382441:DE-467:80TWRF4584-DVD",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-467"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "033 4370",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT016382441:DE-6:033%204370/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT016382441",
+    "id" : "http://lobid.org/item/HT016382441:DE-6:033%204370",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-6"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "61 TWR 1197",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT016382441:DE-A96:61%20TWR%201197/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT016382441",
+    "id" : "http://lobid.org/item/HT016382441:DE-A96:61%20TWR%201197",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-A96"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "112-2195",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT016382441:DE-107:112-2195/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT016382441",
+    "id" : "http://lobid.org/item/HT016382441:DE-107:112-2195",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-107"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "HI088.88-4332104",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT016382441:DE-361:HI088.88-4332104/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT016382441",
+    "id" : "http://lobid.org/item/HT016382441:DE-361:HI088.88-4332104",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-361"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "HK360=L760 B658",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT016382441:DE-361:HK360=L760%20B658/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT016382441",
+    "id" : "http://lobid.org/item/HT016382441:DE-361:HK360=L760%20B658",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-361"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   } ],
   "extent" : [ "418 S. : zahlr. Ill., graph. Darst." ],
   "hbzId" : [ "HT016382441" ],
+  "id" : "http://lobid.org/resource/HT016382441",
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT016382441"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT016382441"
   } ],
   "isbn" : [ "9783527706495" ],
   "issued" : [ "2011" ],
   "language" : [ {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
   } ],
   "medium" : [ {
-    "@id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
+    "id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
   } ],
   "otherTitleInformation" : [ "[frei wie ein Pinguin ; auf einen Blick: Linux schnell und sicher installieren, KDE, GNOME und GUI geschickt einsetzen, OpenOffice clever nutzen ; alles für Ihr Rendezvous mit dem Pinguin]" ],
   "placeOfPublication" : [ "Weinheim" ],
   "publicationStatement" : [ "Weinheim; Wiley-VCH; 2011" ],
   "publisher" : [ "Wiley-VCH" ],
   "sameAs" : [ {
-    "@id" : "http://hub.culturegraph.org/resource/HBZ-HT016382441"
+    "id" : "http://hub.culturegraph.org/resource/HBZ-HT016382441"
   } ],
   "seeAlso" : [ {
-    "@id" : "http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=4027723&custom_att_2=simple_viewer"
+    "id" : "http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=4027723&custom_att_2=simple_viewer"
   } ],
   "statementOfResponsibility" : [ "Richard Blum" ],
   "subject" : [ {
-    "@id" : "http://d-nb.info/gnd/4337730-0",
+    "id" : "http://d-nb.info/gnd/4337730-0",
     "preferredName" : "LINUX",
     "preferredNameForTheSubjectHeading" : "LINUX"
   } ],
   "subjectChain" : [ "LINUX" ],
   "subjectOrder" : [ "http://d-nb.info/gnd/4337730-0" ],
   "tableOfContents" : [ {
-    "@id" : "http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=4027722&custom_att_2=simple_viewer"
+    "id" : "http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=4027722&custom_att_2=simple_viewer"
   } ],
   "title" : [ "Linux für Dummies" ],
-  "type" : [ {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  }, {
-    "@id" : "http://purl.org/ontology/bibo/Book"
-  } ]
+  "type" : [ "http://purl.org/ontology/bibo/Book", "http://purl.org/dc/terms/BibliographicResource" ]
 }

--- a/src/test/resources/output/json/01654/HT016545462.json
+++ b/src/test/resources/output/json/01654/HT016545462.json
@@ -1,46 +1,46 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/HT016545462",
   "collectedBy" : [ {
-    "@id" : "http://lobid.org/resource/NWBib"
+    "id" : "http://lobid.org/resource/NWBib"
   } ],
   "coverage" : [ "Nordkirchen" ],
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/HT016545462/about",
-    "dateCreated" : "20101012"
+    "dateCreated" : "20101012",
+    "id" : "http://lobid.org/resource/HT016545462/about"
   } ],
   "hbzId" : [ "HT016545462" ],
+  "id" : "http://lobid.org/resource/HT016545462",
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT016545462"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT016545462"
   } ],
   "issued" : [ "9999" ],
   "language" : [ {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
   } ],
   "medium" : [ {
-    "@id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
+    "id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
   } ],
   "nwbibsubject" : [ {
-    "@id" : "http://purl.org/lobid/nwbib#s503050"
+    "id" : "http://purl.org/lobid/nwbib#s503050"
   }, {
-    "@id" : "http://purl.org/lobid/nwbib#s843060"
+    "id" : "http://purl.org/lobid/nwbib#s843060"
   } ],
   "placeOfPublication" : [ "Nordkirchen" ],
   "publicationStatement" : [ "Nordkirchen; Heimatverein der Gemeinde Nordkirchen e. V:; 9999" ],
   "publisher" : [ "Heimatverein der Gemeinde Nordkirchen e. V:" ],
   "sameAs" : [ {
-    "@id" : "http://hub.culturegraph.org/resource/HBZ-HT016545462"
+    "id" : "http://hub.culturegraph.org/resource/HBZ-HT016545462"
   } ],
   "subject" : [ {
-    "@id" : "http://d-nb.info/gnd/4151183-9",
+    "id" : "http://d-nb.info/gnd/4151183-9",
     "preferredName" : "Eigentümer",
     "preferredNameForTheSubjectHeading" : "Eigentümer"
   }, {
-    "@id" : "http://d-nb.info/gnd/4156127-2",
+    "id" : "http://d-nb.info/gnd/4156127-2",
     "preferredName" : "Gebäude",
     "preferredNameForTheSubjectHeading" : "Gebäude"
   }, {
-    "@id" : "http://d-nb.info/gnd/4042552-6",
+    "id" : "http://d-nb.info/gnd/4042552-6",
     "preferredName" : "Nordkirchen",
     "preferredNameForThePlaceOrGeographicName" : "Nordkirchen"
   } ],
@@ -48,9 +48,5 @@
   "subjectLabel" : [ "Haus (im weiteren Sinn)" ],
   "subjectOrder" : [ "http://d-nb.info/gnd/4042552-6, http://d-nb.info/gnd/4156127-2, http://d-nb.info/gnd/4151183-9, Geschichte 1805-2000, Verzeichnis" ],
   "title" : [ "Verzeichnis der Gebäude und ihrer Eigentümer auf dem Gebiet der Altgemeinde Nordkirchen 1805, 1900, 1955 und 2000" ],
-  "type" : [ {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  }, {
-    "@id" : "http://purl.org/ontology/bibo/Book"
-  } ]
+  "type" : [ "http://purl.org/ontology/bibo/Book", "http://purl.org/dc/terms/BibliographicResource" ]
 }

--- a/src/test/resources/output/json/01660/HT016608165.json
+++ b/src/test/resources/output/json/01660/HT016608165.json
@@ -1,72 +1,66 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/HT016608165",
   "bibliographicCitation" : [ "Mélodies; Claude Debussy; 1980" ],
   "containedIn" : [ {
-    "@id" : "http://lobid.org/resource/HT016607985"
+    "id" : "http://lobid.org/resource/HT016607985"
   } ],
   "contributor" : [ {
-    "@id" : "http://d-nb.info/gnd/119080389",
+    "id" : "http://d-nb.info/gnd/119080389",
     "preferredName" : "Banville, Théodore de",
     "preferredNameForThePerson" : "Banville, Théodore de"
   } ],
   "contributorLabel" : [ "Debussy, Achille-Claude", "Debussy, Claude-Achille", "Follain de Banville, Théodore", "Banville, Théodore de", "Debussy, ...", "Debussy, Claude Achille", "Banville, Teodoro de", "Debussy, Claudio", "Debjussi, Klod", "Debussy, Claude Achill", "Mesplé, Mady", "Banville, Théodore Follain de", "Debussy, Claude", "Baldwin, Dalton", "Debussy, C. A.", "Debussy, Achille", "Debussy, C.", "Debussy, Claude A.", "Banville, Th. de", "Banville, Théodore" ],
   "contributorOrder" : [ "http://d-nb.info/gnd/118524186 | http://d-nb.info/gnd/130290637 | http://d-nb.info/gnd/124362869 | http://d-nb.info/gnd/119080389" ],
   "creator" : [ {
-    "@id" : "http://d-nb.info/gnd/118524186",
+    "id" : "http://d-nb.info/gnd/118524186",
     "preferredName" : "Debussy, Claude",
     "preferredNameForThePerson" : "Debussy, Claude"
   }, {
-    "@id" : "http://d-nb.info/gnd/124362869",
+    "id" : "http://d-nb.info/gnd/124362869",
     "preferredName" : "Baldwin, Dalton",
     "preferredNameForThePerson" : "Baldwin, Dalton"
   }, {
-    "@id" : "http://d-nb.info/gnd/130290637",
+    "id" : "http://d-nb.info/gnd/130290637",
     "preferredName" : "Mesplé, Mady",
     "preferredNameForThePerson" : "Mesplé, Mady"
   } ],
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/HT016608165/about",
-    "dateCreated" : "20101130"
+    "dateCreated" : "20101130",
+    "id" : "http://lobid.org/resource/HT016608165/about"
   } ],
   "exemplar" : [ {
-    "@id" : "http://lobid.org/item/HT016608165:DE-575:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT016608165:DE-575:/about"
+      "id" : "http://lobid.org/item/HT016608165:DE-575:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT016608165",
+    "id" : "http://lobid.org/item/HT016608165:DE-575:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-575"
+      "id" : "http://lobid.org/organisation/DE-575"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   } ],
   "hbzId" : [ "HT016608165" ],
+  "id" : "http://lobid.org/resource/HT016608165",
   "isPartOf" : [ {
-    "@id" : "http://lobid.org/resource/HT016607985"
+    "id" : "http://lobid.org/resource/HT016607985"
   } ],
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT016608165"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT016608165"
   } ],
   "issued" : [ "1980" ],
   "language" : [ {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/fra"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/fra"
   } ],
   "medium" : [ {
-    "@id" : "http://purl.org/ontology/bibo/AudioDocument"
+    "id" : "http://purl.org/ontology/bibo/AudioDocument"
   } ],
   "otherTitleInformation" : [ "[L 15]" ],
   "placeOfPublication" : [ "[S.l.]" ],
   "publicationStatement" : [ "1980; [S.l.]" ],
   "sameAs" : [ {
-    "@id" : "http://hub.culturegraph.org/resource/HBZ-HT016608165"
+    "id" : "http://hub.culturegraph.org/resource/HBZ-HT016608165"
   } ],
   "statementOfResponsibility" : [ "Claude Debussy. [Text:] (Théodore de Banville)" ],
   "title" : [ "Pierrot" ],
-  "type" : [ {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  }, {
-    "@id" : "http://purl.org/ontology/bibo/Article"
-  } ]
+  "type" : [ "http://purl.org/ontology/bibo/Article", "http://purl.org/dc/terms/BibliographicResource" ]
 }

--- a/src/test/resources/output/json/01746/HT017468042.json
+++ b/src/test/resources/output/json/01746/HT017468042.json
@@ -1,56 +1,50 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/HT017468042",
   "contributingCorporateBodyLabel" : [ "Heritiers de Homann", "Homan. Hered.", "Homannianus Heredus", "Johann Baptist Homann Erben", "Homann Heredibus", "Homanns Erben", "Homanniani Heredes", "Homannische Erben", "Officina Homanniana", "Homaennische Erben", "Bureau Geographique de Homann", "Homannische Offizin", "Homannische Buchhandlung", "Homannianis Heredibus", "Homanni Heredes", "Verlag Homann", "Heritiers d'Homann", "Homann, Verlag", "Homann Heredib.", "Coheredis Homanniani", "Homannische Handlung", "Homannische Officin", "Homannianos Heredes", "Homännischer Verlag", "Homännische Officin", "Homann-Verlag", "Homannsche Erben", "Homännische Erben" ],
   "contributorOrder" : [ "http://d-nb.info/gnd/5293676-4" ],
   "creator" : [ {
-    "@id" : "http://d-nb.info/gnd/5293676-4",
+    "id" : "http://d-nb.info/gnd/5293676-4",
     "preferredName" : "Homannsche Erben",
     "preferredNameForTheCorporateBody" : "Homannsche Erben"
   } ],
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/HT017468042/about",
     "dateCreated" : "20121126",
-    "dateModified" : "20130220"
+    "dateModified" : "20130220",
+    "id" : "http://lobid.org/resource/HT017468042/about"
   } ],
   "exemplar" : [ {
-    "@id" : "http://lobid.org/item/HT017468042:DE-6:RK%2013",
     "callNumber" : "RK 13",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT017468042:DE-6:RK%2013/about"
+      "id" : "http://lobid.org/item/HT017468042:DE-6:RK%2013/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT017468042",
+    "id" : "http://lobid.org/item/HT017468042:DE-6:RK%2013",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-6"
+      "id" : "http://lobid.org/organisation/DE-6"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   } ],
   "extent" : [ "1 Kt. : grenzkolor., flächenkolor., Kupferst." ],
   "hbzId" : [ "HT017468042" ],
+  "id" : "http://lobid.org/resource/HT017468042",
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT017468042"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT017468042"
   } ],
   "issued" : [ "1757" ],
   "language" : [ {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/lat"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/lat"
   } ],
   "longitudeAndLatitude" : [ "E 006 26 -E 008 47 /N 053 11 -N 051 37" ],
   "medium" : [ {
-    "@id" : "http://purl.org/ontology/bibo/Map"
+    "id" : "http://purl.org/ontology/bibo/Map"
   } ],
   "placeOfPublication" : [ "[Nürnberg]" ],
   "publicationStatement" : [ "[Nürnberg]; Homannianos Heredes; 1757" ],
   "publisher" : [ "Homannianos Heredes" ],
   "sameAs" : [ {
-    "@id" : "http://hub.culturegraph.org/resource/HBZ-HT017468042"
+    "id" : "http://hub.culturegraph.org/resource/HBZ-HT017468042"
   } ],
   "statementOfResponsibility" : [ "Mappa publicata per Homannianos Heredes" ],
   "title" : [ "Territorium Seculare Episcopatus Monasterii Munster Germanis dicti. Ubi una cum Episcopatu Osnabr. simul integri Comitatus Bentheim, Steinfurt, Teklenburg, Lingen, Diepholz, Gemen conspiciuntur" ],
-  "type" : [ {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  }, {
-    "@id" : "http://purl.org/ontology/bibo/Book"
-  } ]
+  "type" : [ "http://purl.org/ontology/bibo/Book", "http://purl.org/dc/terms/BibliographicResource" ]
 }

--- a/src/test/resources/output/json/01748/HT017480009.json
+++ b/src/test/resources/output/json/01748/HT017480009.json
@@ -1,82 +1,74 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/HT017480009",
   "contributorLabel" : [ "Fett, Anna Laura" ],
   "contributorOrder" : [ "http://d-nb.info/gnd/1028627270" ],
   "creator" : [ {
-    "@id" : "http://d-nb.info/gnd/1028627270",
+    "id" : "http://d-nb.info/gnd/1028627270",
     "preferredName" : "Fett, Anna Laura",
     "preferredNameForThePerson" : "Fett, Anna Laura"
   } ],
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/HT017480009/about",
     "dateCreated" : "20121206",
-    "dateModified" : "20150227"
+    "dateModified" : "20150227",
+    "id" : "http://lobid.org/resource/HT017480009/about"
   } ],
   "doi" : [ "10.4126/38m-004826540" ],
   "exemplar" : [ {
-    "@id" : "http://lobid.org/item/HT017480009:DE-38M:Elektronische%20Publikation",
     "callNumber" : "Elektronische Publikation",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT017480009:DE-38M:Elektronische%20Publikation/about"
+      "id" : "http://lobid.org/item/HT017480009:DE-38M:Elektronische%20Publikation/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT017480009",
+    "id" : "http://lobid.org/item/HT017480009:DE-38M:Elektronische%20Publikation",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-38M"
+      "id" : "http://lobid.org/organisation/DE-38M"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   } ],
   "extent" : [ "59 S. : Ill." ],
   "fulltextOnline" : [ {
-    "@id" : "http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=4826540&custom_att_2=simple_viewer"
+    "id" : "http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=4826540&custom_att_2=simple_viewer"
   }, {
-    "@id" : "http://nbn-resolving.de/urn:nbn:de:hbz:38m-0000006293"
+    "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:38m-0000006293"
   }, {
-    "@id" : "http://dx.doi.org/10.4126/38m-004826540"
+    "id" : "http://dx.doi.org/10.4126/38m-004826540"
   } ],
   "hasVersion" : [ {
-    "@id" : "http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=4826540&custom_att_2=simple_viewer"
+    "id" : "http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=4826540&custom_att_2=simple_viewer"
   }, {
-    "@id" : "http://nbn-resolving.de/urn:nbn:de:hbz:38m-0000006293"
+    "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:38m-0000006293"
   }, {
-    "@id" : "http://dx.doi.org/10.4126/38m-004826540"
+    "id" : "http://dx.doi.org/10.4126/38m-004826540"
   } ],
   "hbzId" : [ "HT017480009" ],
+  "id" : "http://lobid.org/resource/HT017480009",
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT017480009"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT017480009"
   } ],
   "issued" : [ "2012" ],
   "language" : [ {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/eng"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/eng"
   } ],
   "medium" : [ {
-    "@id" : "http://rdvocab.info/termList/RDACarrierType/1018"
+    "id" : "http://rdvocab.info/termList/RDACarrierType/1018"
   }, {
-    "@id" : "http://rdvocab.info/termList/RDACarrierType/1010"
+    "id" : "http://rdvocab.info/termList/RDACarrierType/1010"
   } ],
   "publicationStatement" : [ "2012" ],
   "sameAs" : [ {
-    "@id" : "http://hub.culturegraph.org/resource/HBZ-HT017480009"
+    "id" : "http://hub.culturegraph.org/resource/HBZ-HT017480009"
   } ],
   "similar" : [ {
-    "@id" : "http://nbn-resolving.de/urn:nbn:de:hbz:38m-0000006293"
+    "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:38m-0000006293"
   }, {
-    "@id" : "http://dx.doi.org/10.4126/38m-004826540"
+    "id" : "http://dx.doi.org/10.4126/38m-004826540"
   } ],
   "statementOfResponsibility" : [ "vorgelegt von Anna Laura Fett" ],
   "subject" : [ {
-    "@id" : "http://dewey.info/class/610/"
+    "id" : "http://dewey.info/class/610/"
   } ],
   "thesisInformation" : [ "Köln, Univ., Diss., 2012" ],
   "title" : [ "Immunohistochemical localization of complement regulatory proteins in the human retina" ],
-  "type" : [ {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  }, {
-    "@id" : "http://purl.org/ontology/bibo/Thesis"
-  }, {
-    "@id" : "http://purl.org/ontology/bibo/Book"
-  } ],
+  "type" : [ "http://purl.org/ontology/bibo/Book", "http://purl.org/dc/terms/BibliographicResource", "http://purl.org/ontology/bibo/Thesis" ],
   "urn" : [ "urn:nbn:de:hbz:38m-0000006293" ]
 }

--- a/src/test/resources/output/json/01752/HT017529028.json
+++ b/src/test/resources/output/json/01752/HT017529028.json
@@ -1,84 +1,80 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/HT017529028",
   "collectedBy" : [ {
-    "@id" : "http://lobid.org/resource/NWBib"
+    "id" : "http://lobid.org/resource/NWBib"
   } ],
   "contributor" : [ {
-    "@id" : "http://d-nb.info/gnd/120534983",
+    "id" : "http://d-nb.info/gnd/120534983",
     "preferredName" : "Neyer, Maria Amata",
     "preferredNameForThePerson" : "Neyer, Maria Amata"
   } ],
   "contributorLabel" : [ "Shutain, Ēdito", "Neyerová, Maria A.", "Stein, Edyta", "Teresa Benedicta a Cruce OCD", "Teresia Benedicta a Cruce", "Neyer, Maria A.", "T. Benedicta", "Stein, Edith", "Cruz, Beata Teresa Benedicta de la", "Cruce, Teresia Benedicta a", "Neyerová, Maria Amata", "Neyer, Amata", "Neyerová, Amata", "Steinová, Edita", "Teresa Benedicta", "Teresa Benedykta", "Teresia Benedicta", "Štejn, Ėdit", "Linssen, Michael", "Neyer, Maria Amata", "Theresia Benedicta" ],
   "contributorOrder" : [ "http://d-nb.info/gnd/118617230 | http://d-nb.info/gnd/12226861X | http://d-nb.info/gnd/120534983" ],
   "creator" : [ {
-    "@id" : "http://d-nb.info/gnd/118617230",
+    "id" : "http://d-nb.info/gnd/118617230",
     "preferredName" : "Stein, Edith",
     "preferredNameForThePerson" : "Stein, Edith"
   } ],
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/HT017529028/about",
     "dateCreated" : "20130131",
-    "dateModified" : "20150323"
+    "dateModified" : "20150323",
+    "id" : "http://lobid.org/resource/HT017529028/about"
   } ],
   "edition" : [ "4., durchges. und korr. Aufl." ],
   "editor" : [ {
-    "@id" : "http://d-nb.info/gnd/12226861X",
+    "id" : "http://d-nb.info/gnd/12226861X",
     "preferredName" : "Linssen, Michael",
     "preferredNameForThePerson" : "Linssen, Michael"
   } ],
   "exemplar" : [ {
-    "@id" : "http://lobid.org/item/HT017529028:DE-1032:PHBB%2018%2F22%2FXVIII",
     "callNumber" : "PHBB 18/22/XVIII",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT017529028:DE-1032:PHBB%2018%2F22%2FXVIII/about"
+      "id" : "http://lobid.org/item/HT017529028:DE-1032:PHBB%2018%2F22%2FXVIII/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT017529028",
+    "id" : "http://lobid.org/item/HT017529028:DE-1032:PHBB%2018%2F22%2FXVIII",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-1032"
+      "id" : "http://lobid.org/organisation/DE-1032"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT017529028:DE-Kn28:PHBB%2018%2F22%2FXVIII",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT017529028:DE-Kn28:PHBB%2018%2F22%2FXVIII/about"
+      "id" : "http://lobid.org/item/HT017529028:DE-Kn28:PHBB%2018%2F22%2FXVIII/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT017529028",
+    "id" : "http://lobid.org/item/HT017529028:DE-Kn28:PHBB%2018%2F22%2FXVIII",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Kn28"
+      "id" : "http://lobid.org/organisation/DE-Kn28"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   } ],
   "extent" : [ "XXXVII, 265 S." ],
   "hbzId" : [ "HT017529028" ],
+  "id" : "http://lobid.org/resource/HT017529028",
   "isPartOf" : [ {
-    "@id" : "http://lobid.org/resource/HT012848847"
+    "id" : "http://lobid.org/resource/HT012848847"
   } ],
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT017529028"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT017529028"
   } ],
   "isbn" : [ "9783451273889" ],
   "issued" : [ "2013" ],
   "language" : [ {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
   } ],
   "medium" : [ {
-    "@id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
+    "id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
   } ],
   "otherTitleInformation" : [ "Studie über Johannes vom Kreuz" ],
   "placeOfPublication" : [ "Freiburg i. Br. [u.a.]" ],
   "publicationStatement" : [ "Freiburg i. Br. [u.a.]; Herder; 2013" ],
   "publisher" : [ "Herder" ],
   "sameAs" : [ {
-    "@id" : "http://hub.culturegraph.org/resource/HBZ-HT017529028"
+    "id" : "http://hub.culturegraph.org/resource/HBZ-HT017529028"
   } ],
   "statementOfResponsibility" : [ "neu bearb. und eingeleitet von Ulrich Dobhan", "hrsg. im Auftr. des Internationalen Edith-Stein-Instituts Würzburg von Michael Linssen unter wiss. Mitarb. von Hanna-Barbara Gerl-Falkovitz" ],
   "subject" : [ {
-    "@id" : "http://d-nb.info/gnd/118640038",
+    "id" : "http://d-nb.info/gnd/118640038",
     "preferredName" : "Juan, de la Cruz",
     "preferredNameForThePerson" : "Juan, de la Cruz"
   } ],
@@ -86,19 +82,13 @@
   "subjectLabel" : [ "Saint Jean de la Croix (1542-1591)", "Yepes, Juan de (1542-1591)", "DeLaCruz, San Juan (1542-1591)", "vom Creütz (1542-1591)", "Cruz, Ioannes (1542-1591)", "Cruce, Ioannis a (1542-1591)", "Yepes y Alvarez, Juan de (1542-1591)", "a Cruce (1542-1591)", "Alvarez, Juan de Yepes y (1542-1591)", "of the Cross (1542-1591)", "Jean de la Croix (1542-1591)", "vom Kreuz (1542-1591)", "LaCruz, Juan de (1542-1591)", "Yepes Alvarez, Juan de (1542-1591)", "vom Creutz (1542-1591)", "Cruz, Juan de la (1542-1591)", "Della Croce, Giovanni (1542-1591)", "Stein, Edith", "Cruce, Johannes a (1542-1591)", "de la Cruz (1542-1591)", "Cruce, Joannis a (1542-1591)", "de la Croix (1542-1591)", "Sankt Johannes vom Kreuz (1542-1591)", "La Cruz, Juan de (1542-1591)", "della Croce (1542-1591)" ],
   "subjectOrder" : [ "http://d-nb.info/gnd/118640038" ],
   "title" : [ "Edith-Stein-Gesamtausgabe, 18: Kreuzeswissenschaft" ],
-  "type" : [ {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  }, {
-    "@id" : "http://purl.org/ontology/bibo/Book"
-  } ],
+  "type" : [ "http://purl.org/ontology/bibo/Book", "http://purl.org/dc/terms/BibliographicResource" ],
   "volume" : [ "2", "Abt. 1, Phänomenologie und Mystik", "18", "D. Schriften zu Mystik und Spiritualität" ],
   "volumeIn" : [ {
     "multiVolumeWork" : [ {
-      "@id" : "http://lobid.org/resource/HT012848847"
+      "id" : "http://lobid.org/resource/HT012848847"
     } ],
     "numbering" : "18",
-    "type" : [ {
-      "@id" : "http://purl.org/lobid/lv#MultiVolumeWorkRelation"
-    } ]
+    "type" : [ "http://purl.org/lobid/lv#MultiVolumeWorkRelation" ]
   } ]
 }

--- a/src/test/resources/output/json/01813/HT018131501.json
+++ b/src/test/resources/output/json/01813/HT018131501.json
@@ -1,57 +1,57 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/HT018131501",
   "bibliographicCitation" : [ "Der Gießerjunge; 34 (2014),1, S. 14-15" ],
   "collectedBy" : [ {
-    "@id" : "http://lobid.org/resource/NWBib"
+    "id" : "http://lobid.org/resource/NWBib"
   } ],
   "containedIn" : [ {
-    "@id" : "http://lobid.org/resource/HT007072426"
+    "id" : "http://lobid.org/resource/HT007072426"
   } ],
   "contributorLabel" : [ "Engelhardt, Manfred" ],
   "contributorOrder" : [ "http://d-nb.info/gnd/124348165" ],
   "coverage" : [ "Düsseldorf" ],
   "creator" : [ {
-    "@id" : "http://d-nb.info/gnd/124348165",
+    "id" : "http://d-nb.info/gnd/124348165",
     "preferredName" : "Engelhardt, Manfred",
     "preferredNameForThePerson" : "Engelhardt, Manfred"
   } ],
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/HT018131501/about",
-    "dateCreated" : "20140115"
+    "dateCreated" : "20140115",
+    "id" : "http://lobid.org/resource/HT018131501/about"
   } ],
   "hbzId" : [ "HT018131501" ],
+  "id" : "http://lobid.org/resource/HT018131501",
   "isPartOf" : [ {
-    "@id" : "http://lobid.org/resource/HT007072426"
+    "id" : "http://lobid.org/resource/HT007072426"
   } ],
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT018131501"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT018131501"
   } ],
   "issued" : [ "2014" ],
   "language" : [ {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
   } ],
   "medium" : [ {
-    "@id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
+    "id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
   } ],
   "nwbibspatial" : [ {
-    "@id" : "http://purl.org/lobid/nwbib-spatial#n46"
+    "id" : "http://purl.org/lobid/nwbib-spatial#n46"
   } ],
   "nwbibsubject" : [ {
-    "@id" : "http://purl.org/lobid/nwbib#s240000"
+    "id" : "http://purl.org/lobid/nwbib#s240000"
   } ],
   "placeOfPublication" : [ "Düsseldorf" ],
   "publicationStatement" : [ "2014; Düsseldorf" ],
   "sameAs" : [ {
-    "@id" : "http://hub.culturegraph.org/resource/HBZ-HT018131501"
+    "id" : "http://hub.culturegraph.org/resource/HBZ-HT018131501"
   } ],
   "statementOfResponsibility" : [ "Manfred Engelhardt" ],
   "subject" : [ {
-    "@id" : "http://d-nb.info/gnd/4137215-3",
+    "id" : "http://d-nb.info/gnd/4137215-3",
     "preferredName" : "Staat Berg",
     "preferredNameForThePlaceOrGeographicName" : "Staat Berg"
   }, {
-    "@id" : "http://d-nb.info/gnd/4013255-9",
+    "id" : "http://d-nb.info/gnd/4013255-9",
     "preferredName" : "Düsseldorf",
     "preferredNameForThePlaceOrGeographicName" : "Düsseldorf"
   } ],
@@ -59,9 +59,5 @@
   "subjectLabel" : [ "Großherzogtum Berg", "Hauptamt (Düsseldorf)", "Düsseldorf. Stadtverordnetenversammlung", "Herzogtum Berg", "Düsseldorf. Hauptamt", "Grafschaft Berg", "Presseamt (Düsseldorf)", "Landeshauptstadt Düsseldorf", "Ducatus Montensis", "Oberbürgermeister (Düsseldorf)", "Düsseldorf. Rat", "Großherzogthum Berg", "Stadtverwaltung (Düsseldorf)", "Djussel'dorf", "Düsseldorf. Stadtverwaltung", "Ratsversammlung (Düsseldorf)", "Düsseldorf. Oberbürgermeister", "Düsseldorf. Presseamt", "Düsseldorf. Oberstadtdirektor", "Düsseldorf. Ratsversammlung", "Grand Duché Berg", "Berg (Staat)", "Duseerduofu", "Dyusserudorufu", "Oberstadtdirektor (Düsseldorf)", "Stadtverordnetenversammlung (Düsseldorf)", "Stadtgemeinde Düsseldorf", "Rat (Düsseldorf)", "Düsseldorf. Organisationsabteilung", "Stadt Düsseldorf" ],
   "subjectOrder" : [ "http://d-nb.info/gnd/4013255-9, http://d-nb.info/gnd/4137215-3, Geschichte 1288-1815" ],
   "title" : [ "Düsseldorf und das bergische Territorium" ],
-  "type" : [ {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  }, {
-    "@id" : "http://purl.org/ontology/bibo/Article"
-  } ]
+  "type" : [ "http://purl.org/ontology/bibo/Article", "http://purl.org/dc/terms/BibliographicResource" ]
 }

--- a/src/test/resources/output/json/01818/HT018187026.json
+++ b/src/test/resources/output/json/01818/HT018187026.json
@@ -1,70 +1,60 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/HT018187026",
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/HT018187026/about",
     "dateCreated" : "20140304",
-    "dateModified" : "20140610"
+    "dateModified" : "20140610",
+    "id" : "http://lobid.org/resource/HT018187026/about"
   } ],
   "exemplar" : [ {
-    "@id" : "http://lobid.org/item/HT018187026:DE-Bi10:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT018187026:DE-Bi10:/about"
+      "id" : "http://lobid.org/item/HT018187026:DE-361:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT018187026",
+    "id" : "http://lobid.org/item/HT018187026:DE-361:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Bi10"
+      "id" : "http://lobid.org/organisation/DE-361"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT018187026:DE-836:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT018187026:DE-836:/about"
+      "id" : "http://lobid.org/item/HT018187026:DE-Bi10:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT018187026",
+    "id" : "http://lobid.org/item/HT018187026:DE-Bi10:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-836"
+      "id" : "http://lobid.org/organisation/DE-Bi10"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT018187026:DE-361:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT018187026:DE-361:/about"
+      "id" : "http://lobid.org/item/HT018187026:DE-836:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT018187026",
+    "id" : "http://lobid.org/item/HT018187026:DE-836:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-361"
+      "id" : "http://lobid.org/organisation/DE-836"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   } ],
   "hbzId" : [ "HT018187026" ],
+  "id" : "http://lobid.org/resource/HT018187026",
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT018187026"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT018187026"
   } ],
   "issn" : [ "21955131" ],
   "issued" : [ "2013 - " ],
   "language" : [ {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
   } ],
   "medium" : [ {
-    "@id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
+    "id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
   } ],
   "placeOfPublication" : [ "Berlin" ],
   "publicationStatement" : [ "Berlin; Logos-Verl.; 2013" ],
   "publisher" : [ "Logos-Verl." ],
   "sameAs" : [ {
-    "@id" : "http://hub.culturegraph.org/resource/HBZ-HT018187026"
+    "id" : "http://hub.culturegraph.org/resource/HBZ-HT018187026"
   } ],
   "title" : [ "Gesundheit und Pflege - aus der Hochschule in die Praxis" ],
-  "type" : [ {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  }, {
-    "@id" : "http://purl.org/ontology/bibo/Series"
-  } ]
+  "type" : [ "http://purl.org/ontology/bibo/Series", "http://purl.org/dc/terms/BibliographicResource" ]
 }

--- a/src/test/resources/output/json/01823/HT018239864.json
+++ b/src/test/resources/output/json/01823/HT018239864.json
@@ -1,176 +1,158 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/HT018239864",
   "collectedBy" : [ {
-    "@id" : "http://lobid.org/resource/NWBib"
+    "id" : "http://lobid.org/resource/NWBib"
   } ],
   "contributorLabel" : [ "Kennedy, Beate" ],
   "contributorOrder" : [ "http://d-nb.info/gnd/1056946172" ],
   "coverage" : [ "Köln" ],
   "creator" : [ {
-    "@id" : "http://d-nb.info/gnd/1056946172",
+    "id" : "http://d-nb.info/gnd/1056946172",
     "preferredName" : "Kennedy, Beate",
     "preferredNameForThePerson" : "Kennedy, Beate"
   } ],
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/HT018239864/about",
-    "dateModified" : "20141113"
+    "dateModified" : "20141113",
+    "id" : "http://lobid.org/resource/HT018239864/about"
   } ],
   "description" : [ {
-    "@id" : "http://deposit.d-nb.de/cgi-bin/dokserv?id=4584991&prov=M&dok_var=1&dok_ext=htm"
+    "id" : "http://deposit.d-nb.de/cgi-bin/dokserv?id=4584991&prov=M&dok_var=1&dok_ext=htm"
   } ],
   "exemplar" : [ {
-    "@id" : "http://lobid.org/item/HT018239864:DE-5:2015%2F1330",
-    "callNumber" : "2015/1330",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT018239864:DE-5:2015%2F1330/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT018239864",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-5"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT018239864:DE-107:115-289",
-    "callNumber" : "115-289",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT018239864:DE-107:115-289/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT018239864",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-107"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT018239864:DE-465:CQWK3670",
     "callNumber" : "CQWK3670",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT018239864:DE-465:CQWK3670/about"
+      "id" : "http://lobid.org/item/HT018239864:DE-465:CQWK3670/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT018239864",
+    "id" : "http://lobid.org/item/HT018239864:DE-465:CQWK3670",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-465"
+      "id" : "http://lobid.org/organisation/DE-465"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT018239864:DE-467:11CQWK6864",
-    "callNumber" : "11CQWK6864",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT018239864:DE-467:11CQWK6864/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT018239864",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-467"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT018239864:DE-385:nc59566",
-    "callNumber" : "nc59566",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT018239864:DE-385:nc59566/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT018239864",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-385"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT018239864:DE-466:CQWK5664",
-    "callNumber" : "CQWK5664",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT018239864:DE-466:CQWK5664/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT018239864",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-466"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT018239864:DE-61:gerw53954.k35",
-    "callNumber" : "gerw53954.k35",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT018239864:DE-61:gerw53954.k35/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT018239864",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-61"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT018239864:DE-294:IFB10325-17",
     "callNumber" : "IFB10325-17",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT018239864:DE-294:IFB10325-17/about"
+      "id" : "http://lobid.org/item/HT018239864:DE-294:IFB10325-17/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT018239864",
+    "id" : "http://lobid.org/item/HT018239864:DE-294:IFB10325-17",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-294"
+      "id" : "http://lobid.org/organisation/DE-294"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "CQWK5664",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT018239864:DE-466:CQWK5664/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT018239864",
+    "id" : "http://lobid.org/item/HT018239864:DE-466:CQWK5664",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-466"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "2015/1330",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT018239864:DE-5:2015%2F1330/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT018239864",
+    "id" : "http://lobid.org/item/HT018239864:DE-5:2015%2F1330",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-5"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "gerw53954.k35",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT018239864:DE-61:gerw53954.k35/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT018239864",
+    "id" : "http://lobid.org/item/HT018239864:DE-61:gerw53954.k35",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-61"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "11CQWK6864",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT018239864:DE-467:11CQWK6864/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT018239864",
+    "id" : "http://lobid.org/item/HT018239864:DE-467:11CQWK6864",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-467"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "nc59566",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT018239864:DE-385:nc59566/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT018239864",
+    "id" : "http://lobid.org/item/HT018239864:DE-385:nc59566",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-385"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "115-289",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT018239864:DE-107:115-289/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT018239864",
+    "id" : "http://lobid.org/item/HT018239864:DE-107:115-289",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-107"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   } ],
   "extent" : [ "517 S." ],
   "hbzId" : [ "HT018239864" ],
+  "id" : "http://lobid.org/resource/HT018239864",
   "inSeries" : [ {
     "numbering" : "17",
     "series" : [ {
-      "@id" : "http://lobid.org/resource/HT016777884"
+      "id" : "http://lobid.org/resource/HT016777884"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/lobid/lv#SeriesRelation"
-    } ]
+    "type" : [ "http://purl.org/lobid/lv#SeriesRelation" ]
   } ],
   "isPartOf" : [ {
-    "@id" : "http://lobid.org/resource/HT016777884"
+    "id" : "http://lobid.org/resource/HT016777884"
   } ],
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT018239864"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT018239864"
   } ],
   "isbn" : [ "3050064641", "9783050103020", "9783050064642" ],
   "issued" : [ "2014" ],
   "language" : [ {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
   } ],
   "medium" : [ {
-    "@id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
+    "id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
   } ],
   "nwbibsubject" : [ {
-    "@id" : "http://purl.org/lobid/nwbib#s768030"
+    "id" : "http://purl.org/lobid/nwbib#s768030"
   } ],
   "otherTitleInformation" : [ "narrative Verfahren und literarische Autorschaft im Gesamtwerk" ],
   "placeOfPublication" : [ "Berlin [u.a.]" ],
   "publicationStatement" : [ "Berlin [u.a.]; de Gruyter; 2014" ],
   "publisher" : [ "de Gruyter" ],
   "sameAs" : [ {
-    "@id" : "http://hub.culturegraph.org/resource/HBZ-HT018239864"
+    "id" : "http://hub.culturegraph.org/resource/HBZ-HT018239864"
   } ],
   "seeAlso" : [ {
-    "@id" : "http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=5764418&custom_att_2=simple_viewer"
+    "id" : "http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=5764418&custom_att_2=simple_viewer"
   } ],
   "statementOfResponsibility" : [ "Beate Kennedy" ],
   "subject" : [ {
-    "@id" : "http://dewey.info/class/400/"
+    "id" : "http://dewey.info/class/400/"
   }, {
-    "@id" : "http://d-nb.info/gnd/118722123",
+    "id" : "http://d-nb.info/gnd/118722123",
     "preferredName" : "Keun, Irmgard",
     "preferredNameForThePerson" : "Keun, Irmgard"
   }, {
-    "@id" : "http://d-nb.info/gnd/4152975-3",
+    "id" : "http://d-nb.info/gnd/4152975-3",
     "preferredName" : "Erzähltheorie",
     "preferredNameForTheSubjectHeading" : "Erzähltheorie"
   } ],
@@ -178,16 +160,10 @@
   "subjectLabel" : [ "Ḳoyn, Irmgard (1905-1982)", "Keina, Irmgarde (1905-1982)", "Kojn, Irmgard (1905-1982)", "Narratologie", "קוין, אירמגרד (1905-1982)" ],
   "subjectOrder" : [ "http://d-nb.info/gnd/118722123, http://d-nb.info/gnd/4152975-3" ],
   "tableOfContents" : [ {
-    "@id" : "http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=5764417&custom_att_2=simple_viewer"
+    "id" : "http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=5764417&custom_att_2=simple_viewer"
   } ],
   "thesisInformation" : [ "Zugl., Göttingen, Univ., Diss., 2013" ],
   "title" : [ "Irmgard Keun: Zeit und Zitat" ],
-  "type" : [ {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  }, {
-    "@id" : "http://purl.org/ontology/bibo/Thesis"
-  }, {
-    "@id" : "http://purl.org/ontology/bibo/Book"
-  } ],
+  "type" : [ "http://purl.org/ontology/bibo/Book", "http://purl.org/dc/terms/BibliographicResource", "http://purl.org/ontology/bibo/Thesis" ],
   "volume" : [ "17" ]
 }

--- a/src/test/resources/output/json/01829/HT018290299.json
+++ b/src/test/resources/output/json/01829/HT018290299.json
@@ -1,11 +1,10 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/HT018290299",
   "collectedBy" : [ {
-    "@id" : "http://lobid.org/resource/NWBib"
+    "id" : "http://lobid.org/resource/NWBib"
   } ],
   "contributor" : [ {
-    "@id" : "http://d-nb.info/gnd/109728068",
+    "id" : "http://d-nb.info/gnd/109728068",
     "preferredName" : "Lehndorff-Felsko, Angelika",
     "preferredNameForThePerson" : "Lehndorff-Felsko, Angelika"
   } ],
@@ -13,139 +12,126 @@
   "contributorOrder" : [ "http://d-nb.info/gnd/109728068" ],
   "coverage" : [ "KÃ¶ln" ],
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/HT018290299/about",
-    "dateModified" : "20150326"
+    "dateModified" : "20150326",
+    "id" : "http://lobid.org/resource/HT018290299/about"
   } ],
   "description" : [ {
-    "@id" : "http://deposit.d-nb.de/cgi-bin/dokserv?id=4675728&prov=M&dok_var=1&dok_ext=htm"
+    "id" : "http://deposit.d-nb.de/cgi-bin/dokserv?id=4675728&prov=M&dok_var=1&dok_ext=htm"
   } ],
   "exemplar" : [ {
-    "@id" : "http://lobid.org/item/HT018290299:DE-5:W%202015%2F2920",
     "callNumber" : "W 2015/2920",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT018290299:DE-5:W%202015%2F2920/about"
+      "id" : "http://lobid.org/item/HT018290299:DE-5:W%202015%2F2920/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT018290299",
+    "id" : "http://lobid.org/item/HT018290299:DE-5:W%202015%2F2920",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-5"
+      "id" : "http://lobid.org/organisation/DE-5"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT018290299:DE-6:3K%2055857",
-    "callNumber" : "3K 55857",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT018290299:DE-6:3K%2055857/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT018290299",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-6"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT018290299:DE-38:17B5040",
-    "callNumber" : "17B5040",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT018290299:DE-38:17B5040/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT018290299",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-38"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT018290299:DE-Kn28:Fbf%207122",
     "callNumber" : "Fbf 7122",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT018290299:DE-Kn28:Fbf%207122/about"
+      "id" : "http://lobid.org/item/HT018290299:DE-Kn28:Fbf%207122/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT018290299",
+    "id" : "http://lobid.org/item/HT018290299:DE-Kn28:Fbf%207122",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Kn28"
+      "id" : "http://lobid.org/organisation/DE-Kn28"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT018290299:DE-5-39:Gb%209130%2F650%20(19)",
+    "callNumber" : "17B5040",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT018290299:DE-38:17B5040/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT018290299",
+    "id" : "http://lobid.org/item/HT018290299:DE-38:17B5040",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-38"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
     "callNumber" : "Gb 9130/650 (19)",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT018290299:DE-5-39:Gb%209130%2F650%20(19)/about"
+      "id" : "http://lobid.org/item/HT018290299:DE-5-39:Gb%209130%2F650%20(19)/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT018290299",
+    "id" : "http://lobid.org/item/HT018290299:DE-5-39:Gb%209130%2F650%20(19)",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-5-39"
+      "id" : "http://lobid.org/organisation/DE-5-39"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "3K 55857",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT018290299:DE-6:3K%2055857/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT018290299",
+    "id" : "http://lobid.org/item/HT018290299:DE-6:3K%2055857",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-6"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   } ],
   "extent" : [ "544 S. : Ill." ],
   "hbzId" : [ "HT018290299" ],
+  "id" : "http://lobid.org/resource/HT018290299",
   "inSeries" : [ {
     "numbering" : "2",
     "series" : [ {
-      "@id" : "http://lobid.org/resource/HT017500108"
+      "id" : "http://lobid.org/resource/HT017500108"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/lobid/lv#SeriesRelation"
-    } ]
+    "type" : [ "http://purl.org/lobid/lv#SeriesRelation" ]
   }, {
     "numbering" : "19",
     "series" : [ {
-      "@id" : "http://lobid.org/resource/HT006514951"
+      "id" : "http://lobid.org/resource/HT006514951"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/lobid/lv#SeriesRelation"
-    } ]
+    "type" : [ "http://purl.org/lobid/lv#SeriesRelation" ]
   } ],
   "isPartOf" : [ {
-    "@id" : "http://lobid.org/resource/HT006514951"
+    "id" : "http://lobid.org/resource/HT006514951"
   }, {
-    "@id" : "http://lobid.org/resource/HT017500108"
+    "id" : "http://lobid.org/resource/HT017500108"
   } ],
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT018290299"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT018290299"
   } ],
   "isbn" : [ "9783954513673" ],
   "issued" : [ "2014" ],
   "language" : [ {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
   } ],
   "medium" : [ {
-    "@id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
+    "id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
   } ],
   "nwbibsubject" : [ {
-    "@id" : "http://purl.org/lobid/nwbib#s240000"
+    "id" : "http://purl.org/lobid/nwbib#s240000"
   } ],
   "otherTitleInformation" : [ "AuszÃ¼ge aus 500 Interviews mit ehemaligen Zwangsarbeiterinnen und Zwangsarbeitern" ],
   "placeOfPublication" : [ "KÃ¶ln" ],
   "publicationStatement" : [ "KÃ¶ln; Emons; 2014" ],
   "publisher" : [ "Emons" ],
   "sameAs" : [ {
-    "@id" : "http://hub.culturegraph.org/resource/HBZ-HT018290299"
+    "id" : "http://hub.culturegraph.org/resource/HBZ-HT018290299"
   } ],
   "seeAlso" : [ {
-    "@id" : "http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=6261757&custom_att_2=simple_viewer"
+    "id" : "http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=6261757&custom_att_2=simple_viewer"
   } ],
   "statementOfResponsibility" : [ "Angelika Lehndorff-Felsko" ],
   "subject" : [ {
-    "@id" : "http://dewey.info/class/943/"
+    "id" : "http://dewey.info/class/943/"
   }, {
-    "@id" : "http://d-nb.info/gnd/4031483-2",
+    "id" : "http://d-nb.info/gnd/4031483-2",
     "preferredName" : "KÃ¶ln",
     "preferredNameForThePlaceOrGeographicName" : "KÃ¶ln"
   }, {
-    "@id" : "http://d-nb.info/gnd/4002641-3",
+    "id" : "http://d-nb.info/gnd/4002641-3",
     "preferredName" : "Arbeitsbedingungen",
     "preferredNameForTheSubjectHeading" : "Arbeitsbedingungen"
   }, {
-    "@id" : "http://d-nb.info/gnd/4139439-2",
+    "id" : "http://d-nb.info/gnd/4139439-2",
     "preferredName" : "Zwangsarbeit",
     "preferredNameForTheSubjectHeading" : "Zwangsarbeit"
   } ],
@@ -153,13 +139,9 @@
   "subjectLabel" : [ "Kerun", "OberbÃ¼rgermeister (KÃ¶ln)", "CÃ¶llen", "Amt fÃ¼r Presse und Ãffentlichkeitsarbeit (KÃ¶ln)", "CÃ¶lln (KÃ¶ln)", "Presse- und Informationsamt (KÃ¶ln)", "KÃ¶ln. Abteilung Zentrale Datenverarbeitung", "Colonia (KÃ¶ln)", "Colonia Ubiorum", "KÃ¶ln. OberbÃ¼rgermeister", "GroÃ-KÃ¶ln", "KÅ«lÅ«niyÄ", "Colonia Agrippina", "KÃ¶ln. Amt fÃ¼r Presse und Ãffentlichkeitsarbeit", "Arbeitsbedingung", "KÃ¶ln. Stadtverordneten-Versammlung", "ADV", "CÃ¶ln", "Arbeitssituation", "KÃ¶ln. Interkulturelles Referat", "Verwaltung (KÃ¶ln)", "KÃ¶ln. Rat", "Stadtverordneten-Versammlung (KÃ¶ln)", "CCAA", "Keln", "Oberstadtdirektor (KÃ¶ln)", "KÃ¶ln. Presse- und Informationsamt", "Stadtverwaltung (KÃ¶ln)", "Colonia Claudia Ara Agrippinensium", "KÃ¶ln. Stadtverwaltung", "Ara Ubiorum", "KÃ¶ln. Verwaltung", "KÃ¶ln. Wasser- und BrÃ¼ckenbauabteilung", "Stadt KÃ¶ln", "Hauptamt (KÃ¶ln)", "KÃ¶ln. Hauptamt", "KÃ¶ln. Oberstadtdirektor", "Arbeit / Bedingung", "Keulen", "Oppidum Ubiorum", "Colonia Agrippinensis", "Cologne", "KÃ¶ln. Nachrichtenamt", "Nachrichtenamt (KÃ¶ln)" ],
   "subjectOrder" : [ "http://d-nb.info/gnd/4031483-2, http://d-nb.info/gnd/4139439-2, http://d-nb.info/gnd/4002641-3, Geschichte" ],
   "tableOfContents" : [ {
-    "@id" : "http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=6261756&custom_att_2=simple_viewer"
+    "id" : "http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=6261756&custom_att_2=simple_viewer"
   } ],
   "title" : [ "\"Uns verschleppten sie nach KÃ¶ln ...\"" ],
-  "type" : [ {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  }, {
-    "@id" : "http://purl.org/ontology/bibo/Book"
-  } ],
+  "type" : [ "http://purl.org/ontology/bibo/Book", "http://purl.org/dc/terms/BibliographicResource" ],
   "volume" : [ "2", "19" ]
 }

--- a/src/test/resources/output/json/01829/HT018295975.json
+++ b/src/test/resources/output/json/01829/HT018295975.json
@@ -1,124 +1,110 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/HT018295975",
   "collectedBy" : [ {
-    "@id" : "http://lobid.org/resource/NWBib"
+    "id" : "http://lobid.org/resource/NWBib"
   } ],
   "contributor" : [ {
-    "@id" : "http://d-nb.info/gnd/12174793X",
+    "id" : "http://d-nb.info/gnd/12174793X",
     "preferredName" : "Mötsch, Johannes",
     "preferredNameForThePerson" : "Mötsch, Johannes"
   } ],
   "contributorLabel" : [ "Mötsch, Johannes", "Moczarski, Norbert" ],
   "contributorOrder" : [ "http://d-nb.info/gnd/136529348 | http://d-nb.info/gnd/12174793X" ],
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/HT018295975/about",
     "dateCreated" : "20140616",
-    "dateModified" : "20141105"
+    "dateModified" : "20141105",
+    "id" : "http://lobid.org/resource/HT018295975/about"
   } ],
   "description" : [ {
-    "@id" : "http://deposit.d-nb.de/cgi-bin/dokserv?id=4685554&prov=M&dok_var=1&dok_ext=htm"
+    "id" : "http://deposit.d-nb.de/cgi-bin/dokserv?id=4685554&prov=M&dok_var=1&dok_ext=htm"
   } ],
   "edition" : [ "1. Aufl." ],
   "editor" : [ {
-    "@id" : "http://d-nb.info/gnd/136529348",
+    "id" : "http://d-nb.info/gnd/136529348",
     "preferredName" : "Moczarski, Norbert",
     "preferredNameForThePerson" : "Moczarski, Norbert"
   } ],
   "exemplar" : [ {
-    "@id" : "http://lobid.org/item/HT018295975:DE-6:3K%2051779",
-    "callNumber" : "3K 51779",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT018295975:DE-6:3K%2051779/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT018295975",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-6"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT018295975:DE-929:2014%2F3450",
     "callNumber" : "2014/3450",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT018295975:DE-929:2014%2F3450/about"
+      "id" : "http://lobid.org/item/HT018295975:DE-929:2014%2F3450/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT018295975",
+    "id" : "http://lobid.org/item/HT018295975:DE-929:2014%2F3450",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-929"
+      "id" : "http://lobid.org/organisation/DE-929"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT018295975:DE-5-39:C%2060%2F145%2F10",
     "callNumber" : "C 60/145/10",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT018295975:DE-5-39:C%2060%2F145%2F10/about"
+      "id" : "http://lobid.org/item/HT018295975:DE-5-39:C%2060%2F145%2F10/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT018295975",
+    "id" : "http://lobid.org/item/HT018295975:DE-5-39:C%2060%2F145%2F10",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-5-39"
+      "id" : "http://lobid.org/organisation/DE-5-39"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "3K 51779",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT018295975:DE-6:3K%2051779/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT018295975",
+    "id" : "http://lobid.org/item/HT018295975:DE-6:3K%2051779",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-6"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   } ],
   "extent" : [ "596 S. : Ill." ],
   "hbzId" : [ "HT018295975" ],
   "honoree" : [ {
-    "@id" : "http://d-nb.info/gnd/12174793X",
+    "id" : "http://d-nb.info/gnd/12174793X",
     "preferredName" : "Mötsch, Johannes",
     "preferredNameForThePerson" : "Mötsch, Johannes"
   } ],
+  "id" : "http://lobid.org/resource/HT018295975",
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT018295975"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT018295975"
   } ],
   "isbn" : [ "9783943539233" ],
   "issued" : [ "2014" ],
   "language" : [ {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
   } ],
   "medium" : [ {
-    "@id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
+    "id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
   } ],
   "otherTitleInformation" : [ "Bonn - Koblenz - Weimar - Meiningen ; Festschrift für Johannes Mötsch zum 65. Geburtstag" ],
   "placeOfPublication" : [ "Leipzig [u.a.]" ],
   "publicationStatement" : [ "Leipzig [u.a.]; Salier; 2014" ],
   "publisher" : [ "Salier" ],
   "sameAs" : [ {
-    "@id" : "http://hub.culturegraph.org/resource/HBZ-HT018295975"
+    "id" : "http://hub.culturegraph.org/resource/HBZ-HT018295975"
   } ],
   "seeAlso" : [ {
-    "@id" : "http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=5852708&custom_att_2=simple_viewer"
+    "id" : "http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=5852708&custom_att_2=simple_viewer"
   } ],
   "statementOfResponsibility" : [ "hrsg. von Norbert Moczarski ..." ],
   "subject" : [ {
-    "@id" : "http://d-nb.info/gnd/4059979-6",
+    "id" : "http://d-nb.info/gnd/4059979-6",
     "preferredName" : "Thüringen",
     "preferredNameForThePlaceOrGeographicName" : "Thüringen"
   }, {
-    "@id" : "http://d-nb.info/gnd/12174793X",
+    "id" : "http://d-nb.info/gnd/12174793X",
     "preferredName" : "Mötsch, Johannes",
     "preferredNameForThePerson" : "Mötsch, Johannes"
   }, {
-    "@id" : "http://dewey.info/class/900/"
+    "id" : "http://dewey.info/class/900/"
   } ],
   "subjectChain" : [ "Thüringen | Geschichte | Aufsatzsammlung", "Mötsch, Johannes | Bibliographie" ],
   "subjectLabel" : [ "Thuringia", "Vereinigte Thüringische Staaten", "Land Thüringen", "Thüringer Land", "Freistaat Thüringen", "Großthüringen" ],
   "subjectOrder" : [ "http://d-nb.info/gnd/12174793X, Bibliographie", "http://d-nb.info/gnd/4059979-6, Geschichte, Aufsatzsammlung" ],
   "tableOfContents" : [ {
-    "@id" : "http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=5852707&custom_att_2=simple_viewer"
+    "id" : "http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=5852707&custom_att_2=simple_viewer"
   } ],
   "title" : [ "Thüringische und rheinische Forschungen" ],
-  "type" : [ {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  }, {
-    "@id" : "http://purl.org/ontology/bibo/Book"
-  }, {
-    "@id" : "http://purl.org/lobid/lv#Festschrift"
-  }, {
-    "@id" : "http://purl.org/lobid/lv#EditedVolume"
-  } ]
+  "type" : [ "http://purl.org/ontology/bibo/Book", "http://purl.org/lobid/lv#EditedVolume", "http://purl.org/lobid/lv#Festschrift", "http://purl.org/dc/terms/BibliographicResource" ]
 }

--- a/src/test/resources/output/json/01831/HT018312899.json
+++ b/src/test/resources/output/json/01831/HT018312899.json
@@ -1,71 +1,67 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/HT018312899",
   "bibliographicCitation" : [ "Grabbe-Jahrbuch ...; 32. 2013 (2014), S. 80-95" ],
   "collectedBy" : [ {
-    "@id" : "http://lobid.org/resource/NWBib"
+    "id" : "http://lobid.org/resource/NWBib"
   } ],
   "containedIn" : [ {
-    "@id" : "http://lobid.org/resource/HT002156174"
+    "id" : "http://lobid.org/resource/HT002156174"
   } ],
   "contributorLabel" : [ "Maes, Sientje" ],
   "contributorOrder" : [ "http://d-nb.info/gnd/1023391147" ],
   "coverage" : [ "Detmold" ],
   "creator" : [ {
-    "@id" : "http://d-nb.info/gnd/1023391147",
+    "id" : "http://d-nb.info/gnd/1023391147",
     "preferredName" : "Maes, Sientje",
     "preferredNameForThePerson" : "Maes, Sientje"
   } ],
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/HT018312899/about",
-    "dateCreated" : "20140702"
+    "dateCreated" : "20140702",
+    "id" : "http://lobid.org/resource/HT018312899/about"
   } ],
   "hbzId" : [ "HT018312899" ],
+  "id" : "http://lobid.org/resource/HT018312899",
   "isPartOf" : [ {
-    "@id" : "http://lobid.org/resource/HT002156174"
+    "id" : "http://lobid.org/resource/HT002156174"
   } ],
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT018312899"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT018312899"
   } ],
   "issued" : [ "2014" ],
   "language" : [ {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
   } ],
   "medium" : [ {
-    "@id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
+    "id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
   } ],
   "nwbibsubject" : [ {
-    "@id" : "http://purl.org/lobid/nwbib#s768030"
+    "id" : "http://purl.org/lobid/nwbib#s768030"
   }, {
-    "@id" : "http://purl.org/lobid/nwbib#s769030"
+    "id" : "http://purl.org/lobid/nwbib#s769030"
   } ],
   "otherTitleInformation" : [ "der Cid als Zeit- und Gattungskritik" ],
   "placeOfPublication" : [ "Bielefeld" ],
   "publicationStatement" : [ "2014; Bielefeld" ],
   "sameAs" : [ {
-    "@id" : "http://hub.culturegraph.org/resource/HBZ-HT018312899"
+    "id" : "http://hub.culturegraph.org/resource/HBZ-HT018312899"
   } ],
   "statementOfResponsibility" : [ "Sientje Maes" ],
   "subject" : [ {
-    "@id" : "http://d-nb.info/gnd/4049716-1",
+    "id" : "http://d-nb.info/gnd/4049716-1",
     "preferredName" : "Rezeption",
     "preferredNameForTheSubjectHeading" : "Rezeption"
   }, {
-    "@id" : "http://d-nb.info/gnd/4124796-6",
-    "preferredName" : "Dramaturgie",
-    "preferredNameForTheSubjectHeading" : "Dramaturgie"
-  }, {
-    "@id" : "http://d-nb.info/gnd/7683386-0",
+    "id" : "http://d-nb.info/gnd/7683386-0",
     "preferredName" : "Grabbe, Christian Dietrich: Der Cid",
     "preferredNameForTheWork" : "Grabbe, Christian Dietrich: Der Cid"
+  }, {
+    "id" : "http://d-nb.info/gnd/4124796-6",
+    "preferredName" : "Dramaturgie",
+    "preferredNameForTheSubjectHeading" : "Dramaturgie"
   } ],
   "subjectChain" : [ "Grabbe, Christian Dietrich | Der Cid | Dramaturgie | Rezeption (231,321)" ],
   "subjectLabel" : [ "Wirkungsgeschichte", "Nachleben", "Fortwirken", "Nachwirkung (Rezeption)", "Aneignung (Rezeption)" ],
   "subjectOrder" : [ "http://d-nb.info/gnd/7683386-0, http://d-nb.info/gnd/4124796-6, http://d-nb.info/gnd/4049716-1" ],
   "title" : [ "Theatraler Exzess und ,gespielte‘ Sinnlosigkeit" ],
-  "type" : [ {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  }, {
-    "@id" : "http://purl.org/ontology/bibo/Article"
-  } ]
+  "type" : [ "http://purl.org/ontology/bibo/Article", "http://purl.org/dc/terms/BibliographicResource" ]
 }

--- a/src/test/resources/output/json/01845/HT018454638.json
+++ b/src/test/resources/output/json/01845/HT018454638.json
@@ -1,20 +1,19 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/HT018454638",
   "collectedBy" : [ {
-    "@id" : "http://lobid.org/resource/NWBib"
+    "id" : "http://lobid.org/resource/NWBib"
   } ],
   "contributingCorporateBodyLabel" : [ "Pfarrgemeinderat Sankt Antonius Abbas Herkenrath", "Pfarrei Sankt Antonius Abbas Herkenrath", "Pfarrgemeinderat", "Pfarrei St. Antonius Abbas Herkenrath", "Pfarrei Sankt Joseph und Sankt Antonius Bergisch Gladbach", "Katholische Kirchengemeinde St. Joseph und St. Antonius Bergisch Gladbach", "Pfarrei Sankt Antonius Abbas Bergisch Gladbach- Herkenrath", "Katholische Kirchengemeinde Sankt Joseph und Sankt Antonius Bergisch Gladbach", "Pfarrei St. Joseph und St. Antonius Bergisch Gladbach" ],
   "contributor" : [ {
-    "@id" : "http://d-nb.info/gnd/1060772442",
+    "id" : "http://d-nb.info/gnd/1060772442",
     "preferredName" : "Pfarrei St. Joseph und St. Antonius Bergisch Gladbach",
     "preferredNameForTheCorporateBody" : "Pfarrei St. Joseph und St. Antonius Bergisch Gladbach"
   }, {
-    "@id" : "http://d-nb.info/gnd/2175350-7",
+    "id" : "http://d-nb.info/gnd/2175350-7",
     "preferredName" : "Pfarrei Sankt Antonius Abbas Herkenrath",
     "preferredNameForTheCorporateBody" : "Pfarrei Sankt Antonius Abbas Herkenrath"
   }, {
-    "@id" : "http://d-nb.info/gnd/172845785",
+    "id" : "http://d-nb.info/gnd/172845785",
     "preferredName" : "Clemens-Schierbaum, Ursula",
     "preferredNameForThePerson" : "Clemens-Schierbaum, Ursula"
   } ],
@@ -22,65 +21,62 @@
   "contributorOrder" : [ "http://d-nb.info/gnd/172845785 | http://d-nb.info/gnd/1060772442 | http://d-nb.info/gnd/2175350-7" ],
   "coverage" : [ "Bergisch Gladbach- Herkenrath" ],
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/HT018454638/about",
     "dateCreated" : "20141111",
-    "dateModified" : "20150303"
+    "dateModified" : "20150303",
+    "id" : "http://lobid.org/resource/HT018454638/about"
   } ],
   "exemplar" : [ {
-    "@id" : "http://lobid.org/item/HT018454638:DE-Kn28:Fc%206601",
     "callNumber" : "Fc 6601",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT018454638:DE-Kn28:Fc%206601/about"
+      "id" : "http://lobid.org/item/HT018454638:DE-Kn28:Fc%206601/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT018454638",
+    "id" : "http://lobid.org/item/HT018454638:DE-Kn28:Fc%206601",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Kn28"
+      "id" : "http://lobid.org/organisation/DE-Kn28"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT018454638:DE-5-39:Gb%207470%2F201",
     "callNumber" : "Gb 7470/201",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT018454638:DE-5-39:Gb%207470%2F201/about"
+      "id" : "http://lobid.org/item/HT018454638:DE-5-39:Gb%207470%2F201/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT018454638",
+    "id" : "http://lobid.org/item/HT018454638:DE-5-39:Gb%207470%2F201",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-5-39"
+      "id" : "http://lobid.org/organisation/DE-5-39"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   } ],
   "extent" : [ "122 S. : zahlr. Ill." ],
   "hbzId" : [ "HT018454638" ],
+  "id" : "http://lobid.org/resource/HT018454638",
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT018454638"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT018454638"
   } ],
   "issued" : [ "2014" ],
   "language" : [ {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
   } ],
   "medium" : [ {
-    "@id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
+    "id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
   } ],
   "nwbibsubject" : [ {
-    "@id" : "http://purl.org/lobid/nwbib#s611030"
+    "id" : "http://purl.org/lobid/nwbib#s611030"
   } ],
   "otherTitleInformation" : [ "Festschrift zum Jubiläum 2014 in St. Antonius Abbas, Herkenrath ; Ausstellungsbegleiter" ],
   "placeOfPublication" : [ "Bergisch Gladbach" ],
   "publicationStatement" : [ "Bergisch Gladbach; 2014" ],
   "sameAs" : [ {
-    "@id" : "http://hub.culturegraph.org/resource/HBZ-HT018454638"
+    "id" : "http://hub.culturegraph.org/resource/HBZ-HT018454638"
   } ],
   "statementOfResponsibility" : [ "[Hrsg.: St. Joseph und St. Antonius, Bergisch-Gladbach. Beitr.: Ursula Clemens-Schierbaum ...]" ],
   "subject" : [ {
-    "@id" : "http://d-nb.info/gnd/1060772442",
+    "id" : "http://d-nb.info/gnd/1060772442",
     "preferredName" : "Pfarrei St. Joseph und St. Antonius Bergisch Gladbach",
     "preferredNameForTheCorporateBody" : "Pfarrei St. Joseph und St. Antonius Bergisch Gladbach"
   }, {
-    "@id" : "http://d-nb.info/gnd/2175350-7",
+    "id" : "http://d-nb.info/gnd/2175350-7",
     "preferredName" : "Pfarrei Sankt Antonius Abbas Herkenrath",
     "preferredNameForTheCorporateBody" : "Pfarrei Sankt Antonius Abbas Herkenrath"
   } ],
@@ -88,9 +84,5 @@
   "subjectLabel" : [ "Pfarrgemeinderat Sankt Antonius Abbas Herkenrath", "Pfarrei Sankt Antonius Abbas Herkenrath. Pfarrgemeinderat", "Pfarrei St. Antonius Abbas Herkenrath", "Pfarrei Sankt Joseph und Sankt Antonius Bergisch Gladbach", "Katholische Kirchengemeinde St. Joseph und St. Antonius Bergisch Gladbach", "Pfarrei Sankt Antonius Abbas Bergisch Gladbach- Herkenrath", "Katholische Kirchengemeinde Sankt Joseph und Sankt Antonius Bergisch Gladbach", "Pfarrgemeinderat (Pfarrei Sankt Antonius Abbas Herkenrath)" ],
   "subjectOrder" : [ "http://d-nb.info/gnd/1060772442, http://d-nb.info/gnd/2175350-7, Geschichte" ],
   "title" : [ "Gottes Haus - Tor des Himmels" ],
-  "type" : [ {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  }, {
-    "@id" : "http://purl.org/ontology/bibo/Book"
-  } ]
+  "type" : [ "http://purl.org/ontology/bibo/Book", "http://purl.org/dc/terms/BibliographicResource" ]
 }

--- a/src/test/resources/output/json/01846/HT018468645.json
+++ b/src/test/resources/output/json/01846/HT018468645.json
@@ -1,92 +1,90 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/HT018468645",
   "collectedBy" : [ {
-    "@id" : "http://lobid.org/resource/NWBib"
+    "id" : "http://lobid.org/resource/NWBib"
   } ],
   "contributorLabel" : [ "Fritsche, Christiane", "Paulmann, Johannes" ],
   "contributorOrder" : [ "http://d-nb.info/gnd/128495626 | http://d-nb.info/gnd/122511158" ],
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/HT018468645/about",
-    "dateCreated" : "20141125"
+    "dateCreated" : "20141125",
+    "id" : "http://lobid.org/resource/HT018468645/about"
   } ],
   "description" : [ {
-    "@id" : "http://deposit.d-nb.de/cgi-bin/dokserv?id=4535439&prov=M&dok_var=1&dok_ext=htm"
+    "id" : "http://deposit.d-nb.de/cgi-bin/dokserv?id=4535439&prov=M&dok_var=1&dok_ext=htm"
   } ],
   "doi" : [ "10.7788/boehlau.9783412216689" ],
   "editor" : [ {
-    "@id" : "http://d-nb.info/gnd/122511158",
+    "id" : "http://d-nb.info/gnd/122511158",
     "preferredName" : "Paulmann, Johannes",
     "preferredNameForThePerson" : "Paulmann, Johannes"
   }, {
-    "@id" : "http://d-nb.info/gnd/128495626",
+    "id" : "http://d-nb.info/gnd/128495626",
     "preferredName" : "Fritsche, Christiane",
     "preferredNameForThePerson" : "Fritsche, Christiane"
   } ],
   "exemplar" : [ {
-    "@id" : "http://lobid.org/item/HT018468645:DE-466:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT018468645:DE-466:/about"
+      "id" : "http://lobid.org/item/HT018468645:DE-466:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT018468645",
+    "id" : "http://lobid.org/item/HT018468645:DE-466:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-466"
+      "id" : "http://lobid.org/organisation/DE-466"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   } ],
   "extent" : [ "394 S. : Ill., graph. Darst." ],
   "fulltextOnline" : [ {
-    "@id" : "http://deposit.d-nb.de/cgi-bin/dokserv?id=4535439&prov=M&dok_var=1&dok_ext=htm"
+    "id" : "http://deposit.d-nb.de/cgi-bin/dokserv?id=4535439&prov=M&dok_var=1&dok_ext=htm"
   } ],
   "hasVersion" : [ {
-    "@id" : "http://deposit.d-nb.de/cgi-bin/dokserv?id=4535439&prov=M&dok_var=1&dok_ext=htm"
+    "id" : "http://deposit.d-nb.de/cgi-bin/dokserv?id=4535439&prov=M&dok_var=1&dok_ext=htm"
   } ],
   "hbzId" : [ "HT018468645" ],
+  "id" : "http://lobid.org/resource/HT018468645",
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT018468645"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT018468645"
   } ],
   "isbn" : [ "9783412216689" ],
   "issued" : [ "2014" ],
   "language" : [ {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
   } ],
   "medium" : [ {
-    "@id" : "http://rdvocab.info/termList/RDACarrierType/1018"
+    "id" : "http://rdvocab.info/termList/RDACarrierType/1018"
   }, {
-    "@id" : "http://rdvocab.info/termList/RDACarrierType/1010"
+    "id" : "http://rdvocab.info/termList/RDACarrierType/1010"
   } ],
   "placeOfPublication" : [ "KÃ¶ln [u.a.]" ],
   "publicationStatement" : [ "KÃ¶ln [u.a.]; BÃ¶hlau; 2014" ],
   "publisher" : [ "BÃ¶hlau" ],
   "sameAs" : [ {
-    "@id" : "http://hub.culturegraph.org/resource/HBZ-HT018468645"
+    "id" : "http://hub.culturegraph.org/resource/HBZ-HT018468645"
   } ],
   "similar" : [ {
-    "@id" : "http://dx.doi.org/10.7788/boehlau.9783412216689"
+    "id" : "http://dx.doi.org/10.7788/boehlau.9783412216689"
   } ],
   "statementOfResponsibility" : [ "Hrsg. von Fritsche, Christiane ; Paulmann, Johannes" ],
   "subject" : [ {
-    "@id" : "http://d-nb.info/gnd/4011882-4",
-    "preferredName" : "Deutschland",
-    "preferredNameForThePlaceOrGeographicName" : "Deutschland"
-  }, {
-    "@id" : "http://d-nb.info/gnd/4020517-4",
-    "preferredName" : "Geschichte",
-    "preferredNameForTheSubjectHeading" : "Geschichte"
-  }, {
-    "@id" : "http://d-nb.info/gnd/4143413-4",
+    "id" : "http://d-nb.info/gnd/4143413-4",
     "preferredName" : "Aufsatzsammlung",
     "preferredNameForTheSubjectHeading" : "Aufsatzsammlung"
   }, {
-    "@id" : "http://d-nb.info/gnd/4219952-9",
+    "id" : "http://d-nb.info/gnd/4011882-4",
+    "preferredName" : "Deutschland",
+    "preferredNameForThePlaceOrGeographicName" : "Deutschland"
+  }, {
+    "id" : "http://d-nb.info/gnd/4020517-4",
+    "preferredName" : "Geschichte",
+    "preferredNameForTheSubjectHeading" : "Geschichte"
+  }, {
+    "id" : "http://d-nb.info/gnd/4219952-9",
     "preferredName" : "Arisierung",
     "preferredNameForTheSubjectHeading" : "Arisierung"
   }, {
-    "@id" : "http://dewey.info/class/943/"
+    "id" : "http://dewey.info/class/943/"
   }, {
-    "@id" : "http://d-nb.info/gnd/4136959-2",
+    "id" : "http://d-nb.info/gnd/4136959-2",
     "preferredName" : "Wiedergutmachung",
     "preferredNameForTheSubjectHeading" : "Wiedergutmachung"
   } ],
@@ -94,11 +92,5 @@
   "subjectLabel" : [ "Deutsche LÃ¤nder", "Heiliges RÃ¶misches Reich", "Deutschland (Gebiet unter Alliierter Besatzung)", "Norddeutscher Bund", "Allemagne (Deutschland)", "Federal Republic of Germany (Deutschland)", "Ç¦umhÅ«rÄ«yat AlmÄniyÄ al-Ittiá¸¥ÄdÄ«ya", "Landesgeschichte", "Germanija", "Germany (Deutschland)", "Rheinbund", "Drittes Reich / Arisierung", "EinzelbeitrÃ¤ge", "Regionalgeschichte", "Deutschland (Bundesrepublik, 1990-)", "RÃ©publique FÃ©dÃ©rale d'Allemagne (Deutschland)", "BeitrÃ¤ge (Formschlagwort)", "Federativnaja Respublika Germanija", "Republic of Germany (Deutschland)", "Repubblica Federale di Germania (Deutschland)", "Deyizhi-Lianbang-Gongheguo", "Niemcy", "Ortsgeschichte", "Zeitgeschichte", "Deutsches Reich", "Deutschland / Arisierung", "Sammelwerk (Formschlagwort)", "Bundesrepublik Deutschland (1990-)", "BRD (1990-)", "BRD", "Deutscher Bund", "FRG" ],
   "subjectOrder" : [ "http://d-nb.info/gnd/4011882-4, http://d-nb.info/gnd/4219952-9, http://d-nb.info/gnd/4136959-2, http://d-nb.info/gnd/4020517-4, http://d-nb.info/gnd/4143413-4" ],
   "title" : [ "\"Arisierung\" und \"Wiedergutmachung\" in deutschen StÃ¤dten" ],
-  "type" : [ {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  }, {
-    "@id" : "http://purl.org/ontology/bibo/Book"
-  }, {
-    "@id" : "http://purl.org/lobid/lv#EditedVolume"
-  } ]
+  "type" : [ "http://purl.org/ontology/bibo/Book", "http://purl.org/lobid/lv#EditedVolume", "http://purl.org/dc/terms/BibliographicResource" ]
 }

--- a/src/test/resources/output/json/01858/HT018585406.json
+++ b/src/test/resources/output/json/01858/HT018585406.json
@@ -1,82 +1,76 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/HT018585406",
   "collectedBy" : [ {
-    "@id" : "http://lobid.org/resource/RPB"
+    "id" : "http://lobid.org/resource/RPB"
   }, {
-    "@id" : "http://lobid.org/resource/Edoweb"
+    "id" : "http://lobid.org/resource/Edoweb"
   } ],
   "contributingCorporateBodyLabel" : [ "Entwicklungsagentur Rheinland-Pfalz", "Conférence Franco-Germano-Suisse du Rhin Supérieur", "Entwicklungsagentur Rheinland-Pfalz e.V.", "Deutsch-Französisch-Schweizerische Oberrheinkonferenz", "ORK", "Conférence du Rhin Supérieur", "Oberrheinkonferenz" ],
   "contributor" : [ {
-    "@id" : "http://d-nb.info/gnd/5079636-7",
+    "id" : "http://d-nb.info/gnd/5079636-7",
     "preferredName" : "Deutsch-Französisch-Schweizerische Oberrheinkonferenz",
     "preferredNameForTheCorporateBody" : "Deutsch-Französisch-Schweizerische Oberrheinkonferenz"
   }, {
-    "@id" : "http://d-nb.info/gnd/16080300-7",
+    "id" : "http://d-nb.info/gnd/16080300-7",
     "preferredName" : "Entwicklungsagentur Rheinland-Pfalz",
     "preferredNameForTheCorporateBody" : "Entwicklungsagentur Rheinland-Pfalz"
   }, {
-    "@id" : "http://d-nb.info/gnd/121842118",
+    "id" : "http://d-nb.info/gnd/121842118",
     "preferredName" : "Clev, Hans-Günther",
     "preferredNameForThePerson" : "Clev, Hans-Günther"
   } ],
   "contributorLabel" : [ "Clev, Hans-Günther" ],
   "contributorOrder" : [ "http://d-nb.info/gnd/121842118 | http://d-nb.info/gnd/16080300-7 | http://d-nb.info/gnd/5079636-7" ],
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/HT018585406/about",
-    "dateCreated" : "20150319"
+    "dateCreated" : "20150319",
+    "id" : "http://lobid.org/resource/HT018585406/about"
   } ],
   "exemplar" : [ {
-    "@id" : "http://lobid.org/item/HT018585406:DE-107:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT018585406:DE-107:/about"
+      "id" : "http://lobid.org/item/HT018585406:DE-107:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT018585406",
+    "id" : "http://lobid.org/item/HT018585406:DE-107:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-107"
+      "id" : "http://lobid.org/organisation/DE-107"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   } ],
   "extent" : [ "45 S. : Ill., Kt." ],
   "hbzId" : [ "HT018585406" ],
+  "id" : "http://lobid.org/resource/HT018585406",
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT018585406"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT018585406"
   } ],
   "issued" : [ "2006" ],
   "language" : [ {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
   } ],
   "medium" : [ {
-    "@id" : "http://rdvocab.info/termList/RDACarrierType/1018"
+    "id" : "http://rdvocab.info/termList/RDACarrierType/1018"
   }, {
-    "@id" : "http://rdvocab.info/termList/RDACarrierType/1010"
+    "id" : "http://rdvocab.info/termList/RDACarrierType/1010"
   } ],
   "placeOfPublication" : [ "Kaiserslautern" ],
   "publicationStatement" : [ "Kaiserslautern; 2006" ],
   "sameAs" : [ {
-    "@id" : "http://hub.culturegraph.org/resource/HBZ-HT018585406"
+    "id" : "http://hub.culturegraph.org/resource/HBZ-HT018585406"
   } ],
   "statementOfResponsibility" : [ "Deutsch-Französisch-Schweizerische Oberrheinkonferenz, AG Raumordnung. Hrsg.: Entwicklungsagentur Rheinland-Pfalz e.V. Red.: Hans-Günther Clev ..." ],
   "subject" : [ {
-    "@id" : "http://d-nb.info/gnd/4034268-2",
+    "id" : "http://d-nb.info/gnd/4034268-2",
     "preferredName" : "Landesplanung",
     "preferredNameForTheSubjectHeading" : "Landesplanung"
   }, {
-    "@id" : "http://d-nb.info/gnd/4075561-7",
+    "id" : "http://d-nb.info/gnd/4075561-7",
     "preferredName" : "Oberrheinisches Tiefland",
     "preferredNameForThePlaceOrGeographicName" : "Oberrheinisches Tiefland"
   }, {
-    "@id" : "http://purl.org/lobid/rpb#n572020"
+    "id" : "http://purl.org/lobid/rpb#n572020"
   } ],
   "subjectChain" : [ "Oberrheinisches Tiefland | Landesplanung" ],
   "subjectLabel" : [ "Gebietsplanung", "Landesentwicklungsplanung", "Oberrheinische Tiefebene", "Oberrheinlande", "Oberrhein-Gebiet", "Oberrhein (Region)", "Oberrheinebene" ],
   "subjectOrder" : [ "http://d-nb.info/gnd/4075561-7, http://d-nb.info/gnd/4034268-2" ],
   "title" : [ "Endbericht Workshop Der Oberrhein als Europäische Metropolregion" ],
-  "type" : [ {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  }, {
-    "@id" : "http://purl.org/ontology/bibo/Book"
-  } ]
+  "type" : [ "http://purl.org/ontology/bibo/Book", "http://purl.org/dc/terms/BibliographicResource" ]
 }

--- a/src/test/resources/output/json/01861/HT018612706.json
+++ b/src/test/resources/output/json/01861/HT018612706.json
@@ -1,148 +1,136 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/HT018612706",
   "collectedBy" : [ {
-    "@id" : "http://lobid.org/resource/NWBib"
+    "id" : "http://lobid.org/resource/NWBib"
   } ],
   "contributingCorporateBodyLabel" : [ "Zentralarchiv des Internationalen Kunsthandels e.V.", "Zentralarchiv des Internationalen Kunsthandels", "ZADIK" ],
   "contributor" : [ {
-    "@id" : "http://d-nb.info/gnd/10040152-1",
-    "preferredName" : "Zentralarchiv des Internationalen Kunsthandels",
-    "preferredNameForTheCorporateBody" : "Zentralarchiv des Internationalen Kunsthandels"
-  }, {
-    "@id" : "http://d-nb.info/gnd/1069643262",
+    "id" : "http://d-nb.info/gnd/1069643262",
     "preferredName" : "49. Art Cologne, 2015, KÃ¶ln"
   }, {
-    "@id" : "http://d-nb.info/gnd/1050748387",
+    "id" : "http://d-nb.info/gnd/1050748387",
     "preferredName" : "Herzog, GÃ¼nter",
     "preferredNameForThePerson" : "Herzog, GÃ¼nter"
+  }, {
+    "id" : "http://d-nb.info/gnd/10040152-1",
+    "preferredName" : "Zentralarchiv des Internationalen Kunsthandels",
+    "preferredNameForTheCorporateBody" : "Zentralarchiv des Internationalen Kunsthandels"
   } ],
   "contributorLabel" : [ "Herzog, GÃ¼nter" ],
   "contributorOrder" : [ "http://d-nb.info/gnd/1050748387 | http://d-nb.info/gnd/1069643262 | http://d-nb.info/gnd/10040152-1" ],
   "coverage" : [ "DÃ¼sseldorf", "KÃ¶ln" ],
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/HT018612706/about",
-    "dateModified" : "20150804"
+    "dateModified" : "20150804",
+    "id" : "http://lobid.org/resource/HT018612706/about"
   } ],
   "description" : [ {
-    "@id" : "http://deposit.d-nb.de/cgi-bin/dokserv?id=5203696&prov=M&dok_var=1&dok_ext=htm"
+    "id" : "http://deposit.d-nb.de/cgi-bin/dokserv?id=5203696&prov=M&dok_var=1&dok_ext=htm"
   } ],
   "exemplar" : [ {
-    "@id" : "http://lobid.org/item/HT018612706:DE-5:4'%202015%2F189",
-    "callNumber" : "4' 2015/189",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT018612706:DE-5:4'%202015%2F189/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT018612706",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-5"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT018612706:DE-5:In%20Bearbeitung",
-    "callNumber" : "In Bearbeitung",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT018612706:DE-5:In%20Bearbeitung/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT018612706",
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT018612706:DE-5-7:kund960.h582",
-    "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT018612706:DE-5-7:kund960.h582/about"
-    } ],
-    "exemplarOf" : "http://lobid.org/resource/HT018612706",
-    "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-5-7"
-    } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
-  }, {
-    "@id" : "http://lobid.org/item/HT018612706:DE-465:KFG1163-26%2F26",
     "callNumber" : "KFG1163-26/26",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT018612706:DE-465:KFG1163-26%2F26/about"
+      "id" : "http://lobid.org/item/HT018612706:DE-465:KFG1163-26%2F26/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT018612706",
+    "id" : "http://lobid.org/item/HT018612706:DE-465:KFG1163-26%2F26",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-465"
+      "id" : "http://lobid.org/organisation/DE-465"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT018612706:DE-61:kund960.h582",
     "callNumber" : "kund960.h582",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT018612706:DE-61:kund960.h582/about"
+      "id" : "http://lobid.org/item/HT018612706:DE-61:kund960.h582/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT018612706",
+    "id" : "http://lobid.org/item/HT018612706:DE-61:kund960.h582",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-61"
+      "id" : "http://lobid.org/organisation/DE-61"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "In Bearbeitung",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT018612706:DE-5:In%20Bearbeitung/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT018612706",
+    "id" : "http://lobid.org/item/HT018612706:DE-5:In%20Bearbeitung",
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "callNumber" : "4' 2015/189",
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT018612706:DE-5:4'%202015%2F189/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT018612706",
+    "id" : "http://lobid.org/item/HT018612706:DE-5:4'%202015%2F189",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-5"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
+  }, {
+    "describedby" : [ {
+      "id" : "http://lobid.org/item/HT018612706:DE-5-7:kund960.h582/about"
+    } ],
+    "exemplarOf" : "http://lobid.org/resource/HT018612706",
+    "id" : "http://lobid.org/item/HT018612706:DE-5-7:kund960.h582",
+    "owner" : [ {
+      "id" : "http://lobid.org/organisation/DE-5-7"
+    } ],
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   } ],
   "extent" : [ "173 S. : zahlr. Ill." ],
   "hbzId" : [ "HT018612706" ],
+  "id" : "http://lobid.org/resource/HT018612706",
   "inSeries" : [ {
     "numbering" : "25/26",
     "series" : [ {
-      "@id" : "http://lobid.org/resource/HT014679525"
+      "id" : "http://lobid.org/resource/HT014679525"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/lobid/lv#SeriesRelation"
-    } ]
+    "type" : [ "http://purl.org/lobid/lv#SeriesRelation" ]
   } ],
   "isPartOf" : [ {
-    "@id" : "http://lobid.org/resource/HT014679525"
+    "id" : "http://lobid.org/resource/HT014679525"
   } ],
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT018612706"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT018612706"
   } ],
   "isbn" : [ "9783903004108" ],
   "issued" : [ "2015" ],
   "language" : [ {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
   } ],
   "medium" : [ {
-    "@id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
+    "id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
   } ],
   "nwbibsubject" : [ {
-    "@id" : "http://purl.org/lobid/nwbib#s842000"
+    "id" : "http://purl.org/lobid/nwbib#s842000"
   }, {
-    "@id" : "http://purl.org/lobid/nwbib#s841060"
+    "id" : "http://purl.org/lobid/nwbib#s841060"
   } ],
   "otherTitleInformation" : [ "[... anlÃ¤sslich der gleichnamigen Ausstellung auf der ART COLOGNE 16. - 19.4.2015, und im ZADIK, 4.5. - 28.8.2015]" ],
   "placeOfPublication" : [ "Wien", "KÃ¶ln" ],
   "publicationStatement" : [ "Wien; Verl. fÃ¼r moderne Kunst; KÃ¶ln; Zentralarchiv des Internationalen Kunsthandels e.V., ZADIK; 2015" ],
   "publisher" : [ "Zentralarchiv des Internationalen Kunsthandels e.V., ZADIK", "Verl. fÃ¼r moderne Kunst" ],
   "sameAs" : [ {
-    "@id" : "http://hub.culturegraph.org/resource/HBZ-HT018612706"
+    "id" : "http://hub.culturegraph.org/resource/HBZ-HT018612706"
   } ],
   "statementOfResponsibility" : [ "[Texte: GÃ¼nter Herzog ...]" ],
   "subject" : [ {
-    "@id" : "http://d-nb.info/gnd/4013255-9",
-    "preferredName" : "DÃ¼sseldorf",
-    "preferredNameForThePlaceOrGeographicName" : "DÃ¼sseldorf"
-  }, {
-    "@id" : "http://d-nb.info/gnd/4011889-7",
+    "id" : "http://d-nb.info/gnd/4011889-7",
     "preferredName" : "Deutschland, Bundesrepublik",
     "preferredNameForThePlaceOrGeographicName" : "Deutschland"
   }, {
-    "@id" : "http://dewey.info/class/700/"
+    "id" : "http://d-nb.info/gnd/4013255-9",
+    "preferredName" : "DÃ¼sseldorf",
+    "preferredNameForThePlaceOrGeographicName" : "DÃ¼sseldorf"
   }, {
-    "@id" : "http://d-nb.info/gnd/4076259-2",
+    "id" : "http://dewey.info/class/700/"
+  }, {
+    "id" : "http://d-nb.info/gnd/4076259-2",
     "preferredName" : "Pop-Art",
     "preferredNameForTheSubjectHeading" : "Pop-Art"
   }, {
-    "@id" : "http://d-nb.info/gnd/4031483-2",
+    "id" : "http://d-nb.info/gnd/4031483-2",
     "preferredName" : "KÃ¶ln",
     "preferredNameForThePlaceOrGeographicName" : "KÃ¶ln"
   } ],
@@ -150,12 +138,6 @@
   "subjectLabel" : [ "Kerun", "Presseamt (DÃ¼sseldorf)", "NRF", "CÃ¶lln (KÃ¶ln)", "KÃ¶ln. Abteilung Zentrale Datenverarbeitung", "Colonia (KÃ¶ln)", "Pop-Kunst", "Colonia Ubiorum", "KÃ¶ln. OberbÃ¼rgermeister", "RÃ©publique FÃ©dÃ©rale d'Allemagne (Deutschland, Bundesrepublik)", "KÃ¶ln. Amt fÃ¼r Presse und Ãffentlichkeitsarbeit", "Ratsversammlung (DÃ¼sseldorf)", "KÃ¶ln. Stadtverordneten-Versammlung", "NÃ©metorszÃ¡gi SzÃ¶vetsÃ©gi KÅztÃ¡rsasÃ¡g (Deutschland, Bundesrepublik)", "ADV", "Niemiecka Republika Federalna Niemiecka Republika Federalna", "Stadt DÃ¼sseldorf", "BRD (1949-1990)", "DÃ¼sseldorf. Oberstadtdirektor", "KÃ¶ln. Rat", "RFN", "Stadtverordneten-Versammlung (KÃ¶ln)", "Djussel'dorf", "Republic of Germany (Deutschland, Bundesrepublik)", "CCAA", "RepÃºblica Federal de Alemania (Deutschland, Bundesrepublik)", "Alemania (Deutschland, Bundesrepublik)", "DÃ¼sseldorf. OberbÃ¼rgermeister", "Stadtverwaltung (DÃ¼sseldorf)", "KÃ¶ln. Stadtverwaltung", "Ara Ubiorum", "Allemagne (Deutschland, Bundesrepublik)", "Deutschland (1949-1990)", "Germany (Deutschland, Bundesrepublik)", "Dyusserudorufu", "KÃ¶ln. Hauptamt", "KÃ¶ln. Oberstadtdirektor", "FÃ¶rbundsrepublikken Tyskland (Deutschland, Bundesrepublik)", "AlmÄniyÄ (Deutschland, Bundesrepublik)", "DÃ¼sseldorf. Stadtverwaltung", "Keulen", "Alemanha (Deutschland, Bundesrepublik)", "Oppidum Ubiorum", "Cologne", "KÃ¶ln. Nachrichtenamt", "Stadtgemeinde DÃ¼sseldorf", "OberbÃ¼rgermeister (DÃ¼sseldorf)", "OberbÃ¼rgermeister (KÃ¶ln)", "Westdeutschland (Bundesrepublik, 1949-1990)", "CÃ¶llen", "Deutschland (1949-1990, Bundesrepublik)", "Amt fÃ¼r Presse und Ãffentlichkeitsarbeit (KÃ¶ln)", "Presse- und Informationsamt (KÃ¶ln)", "DÃ¼sseldorf. Stadtverordnetenversammlung", "Bondsrepubliek Duitsland (Deutschland, Bundesrepublik)", "Federal Republic of Germany (Deutschland, Bundesrepublik)", "GroÃ-KÃ¶ln", "KÅ«lÅ«niyÄ", "Colonia Agrippina", "DÃ¼sseldorf. Ratsversammlung", "CÃ¶ln", "Bundesrepublik Deutschland (1949-1990)", "RepÃºblica Federal da Alemanha (Deutschland, Bundesrepublik)", "KÃ¶ln. Interkulturelles Referat", "Verwaltung (KÃ¶ln)", "Landeshauptstadt DÃ¼sseldorf", "DÃ¼sseldorf. Hauptamt", "Keln", "Oberstadtdirektor (KÃ¶ln)", "DÃ¼sseldorf. Organisationsabteilung", "KÃ¶ln. Presse- und Informationsamt", "Stadtverwaltung (KÃ¶ln)", "Pop art", "Republik Federasi Djerman (Deutschland, Bundesrepublik)", "Colonia Claudia Ara Agrippinensium", "Hauptamt (DÃ¼sseldorf)", "Republika Federalna Niemiec (Deutschland, Bundesrepublik)", "Duseerduofu", "KÃ¶ln. Verwaltung", "Rat (DÃ¼sseldorf)", "KÃ¶ln. Wasser- und BrÃ¼ckenbauabteilung", "Repubblica Federale di Germania (Deutschland, Bundesrepublik)", "Stadt KÃ¶ln", "Hauptamt (KÃ¶ln)", "Almanija (Deutschland, Bundesrepublik)", "BRD", "Saksan Liittotasavalta (Deutschland, Bundesrepublik)", "Stadtverordnetenversammlung (DÃ¼sseldorf)", "DÃ¼sseldorf. Presseamt", "Oberstadtdirektor (DÃ¼sseldorf)", "DÃ¼sseldorf. Rat", "FRG", "Colonia Agrippinensis", "FÃ¶rbundsrepubliken Tyskland (Deutschland, Bundesrepublik)", "Nachrichtenamt (KÃ¶ln)" ],
   "subjectOrder" : [ "http://d-nb.info/gnd/4011889-7, http://d-nb.info/gnd/4076259-2, Geschichte 1959-1972, Ausstellung, KÃ¶ln <2015>", "http://d-nb.info/gnd/4013255-9, http://d-nb.info/gnd/4031483-2, http://d-nb.info/gnd/4076259-2, Geschichte 1959-1972, Ausstellung, KÃ¶ln <2015>" ],
   "title" : [ "Wie die Pop Art nach Deutschland kam" ],
-  "type" : [ {
-    "@id" : "http://purl.org/ontology/bibo/Proceedings"
-  }, {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  }, {
-    "@id" : "http://purl.org/ontology/bibo/Book"
-  } ],
+  "type" : [ "http://purl.org/ontology/bibo/Book", "http://purl.org/dc/terms/BibliographicResource", "http://purl.org/ontology/bibo/Proceedings" ],
   "volume" : [ "25/26" ]
 }

--- a/src/test/resources/output/json/01861/HT018617137.json
+++ b/src/test/resources/output/json/01861/HT018617137.json
@@ -1,72 +1,66 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/HT018617137",
   "collectedBy" : [ {
-    "@id" : "http://lobid.org/resource/NWBib"
+    "id" : "http://lobid.org/resource/NWBib"
   } ],
   "contributorLabel" : [ "Helm, Eva Maria" ],
   "contributorOrder" : [ "Helm, Eva Maria" ],
   "creatorName" : [ "Helm, Eva Maria" ],
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/HT018617137/about",
-    "dateCreated" : "20150424"
+    "dateCreated" : "20150424",
+    "id" : "http://lobid.org/resource/HT018617137/about"
   } ],
   "exemplar" : [ {
-    "@id" : "http://lobid.org/item/HT018617137:DE-5:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT018617137:DE-5:/about"
+      "id" : "http://lobid.org/item/HT018617137:DE-5:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT018617137",
+    "id" : "http://lobid.org/item/HT018617137:DE-5:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-5"
+      "id" : "http://lobid.org/organisation/DE-5"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   } ],
   "extent" : [ "55 S. : Ill." ],
   "fulltextOnline" : [ {
-    "@id" : "http://nbn-resolving.de/urn:nbn:de:hbz:5:2-66128"
+    "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:5:2-66128"
   } ],
   "hasVersion" : [ {
-    "@id" : "http://nbn-resolving.de/urn:nbn:de:hbz:5:2-66128"
+    "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:5:2-66128"
   } ],
   "hbzId" : [ "HT018617137" ],
+  "id" : "http://lobid.org/resource/HT018617137",
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT018617137"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT018617137"
   } ],
   "isbn" : [ "9783981642216" ],
   "issued" : [ "2015" ],
   "language" : [ {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
   } ],
   "medium" : [ {
-    "@id" : "http://rdvocab.info/termList/RDACarrierType/1018"
+    "id" : "http://rdvocab.info/termList/RDACarrierType/1018"
   }, {
-    "@id" : "http://rdvocab.info/termList/RDACarrierType/1010"
+    "id" : "http://rdvocab.info/termList/RDACarrierType/1010"
   } ],
   "nwbibspatial" : [ {
-    "@id" : "http://purl.org/lobid/nwbib-spatial#n01"
+    "id" : "http://purl.org/lobid/nwbib-spatial#n01"
   } ],
   "nwbibsubject" : [ {
-    "@id" : "http://purl.org/lobid/nwbib#s796000"
+    "id" : "http://purl.org/lobid/nwbib#s796000"
   } ],
   "otherTitleInformation" : [ "Forschung gestaltet unsere Lebenswelten" ],
   "placeOfPublication" : [ "KÃ¶ln" ],
   "publicationStatement" : [ "KÃ¶ln; Projekt \"Nachhaltige Forschung an Fachhochschulen in NRW\"; 2015" ],
   "publisher" : [ "Projekt \"Nachhaltige Forschung an Fachhochschulen in NRW\"" ],
   "sameAs" : [ {
-    "@id" : "http://hub.culturegraph.org/resource/HBZ-HT018617137"
+    "id" : "http://hub.culturegraph.org/resource/HBZ-HT018617137"
   } ],
   "similar" : [ {
-    "@id" : "http://nbn-resolving.de/urn:nbn:de:hbz:5:2-66128"
+    "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:5:2-66128"
   } ],
   "statementOfResponsibility" : [ "[Text: Eva Maria Helm]" ],
   "title" : [ "Nachhaltige Forschung an Fachhochschulen in NRW" ],
-  "type" : [ {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  }, {
-    "@id" : "http://purl.org/ontology/bibo/Book"
-  } ],
+  "type" : [ "http://purl.org/ontology/bibo/Book", "http://purl.org/dc/terms/BibliographicResource" ],
   "urn" : [ "urn:nbn:de:hbz:5:2-66128" ]
 }

--- a/src/test/resources/output/json/01870/HT018700720.json
+++ b/src/test/resources/output/json/01870/HT018700720.json
@@ -1,100 +1,92 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/HT018700720",
   "contributingCorporateBodyLabel" : [ "Deutschland", "BZgA, Bundeszentrale fÃ¼r Gesundheitliche AufklÃ¤rung", "FCHE", "BZgA", "Bundeszentrale fÃ¼r Gesundheitliche AufklÃ¤rung", "Federal Centre for Health Education" ],
   "contributor" : [ {
-    "@id" : "http://d-nb.info/gnd/2006655-7",
+    "id" : "http://d-nb.info/gnd/2006655-7",
     "preferredName" : "Bundeszentrale fÃ¼r Gesundheitliche AufklÃ¤rung",
     "preferredNameForTheCorporateBody" : "Bundeszentrale fÃ¼r Gesundheitliche AufklÃ¤rung"
   }, {
-    "@id" : "http://d-nb.info/gnd/136371671",
+    "id" : "http://d-nb.info/gnd/136371671",
     "preferredName" : "Amrhein, Ludwig",
     "preferredNameForThePerson" : "Amrhein, Ludwig"
   }, {
-    "@id" : "http://d-nb.info/gnd/129961604",
-    "preferredName" : "Heusinger, Josefine",
-    "preferredNameForThePerson" : "Heusinger, Josefine"
-  }, {
-    "@id" : "http://d-nb.info/gnd/115325859",
+    "id" : "http://d-nb.info/gnd/115325859",
     "preferredName" : "Wolter, Birgit",
     "preferredNameForThePerson" : "Wolter, Birgit"
+  }, {
+    "id" : "http://d-nb.info/gnd/129961604",
+    "preferredName" : "Heusinger, Josefine",
+    "preferredNameForThePerson" : "Heusinger, Josefine"
   } ],
   "contributorLabel" : [ "Heusinger, Josefine", "Amrhein, Ludwig", "Wolter, Birgit", "Ottovay, Kathrin" ],
   "contributorName" : [ "Ottovay, Kathrin" ],
   "contributorOrder" : [ "http://d-nb.info/gnd/136371671 | http://d-nb.info/gnd/129961604 | Ottovay, Kathrin | http://d-nb.info/gnd/115325859 | http://d-nb.info/gnd/2006655-7" ],
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/HT018700720/about",
     "dateCreated" : "20150716",
-    "dateModified" : "20150720"
+    "dateModified" : "20150720",
+    "id" : "http://lobid.org/resource/HT018700720/about"
   } ],
   "doi" : [ "10.4126/38m-006326817" ],
   "edition" : [ "Aufl.: 1.3.02.15" ],
   "exemplar" : [ {
-    "@id" : "http://lobid.org/item/HT018700720:DE-38M:Elektronische%20Publikation",
     "callNumber" : "Elektronische Publikation",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT018700720:DE-38M:Elektronische%20Publikation/about"
+      "id" : "http://lobid.org/item/HT018700720:DE-38M:Elektronische%20Publikation/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT018700720",
+    "id" : "http://lobid.org/item/HT018700720:DE-38M:Elektronische%20Publikation",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-38M"
+      "id" : "http://lobid.org/organisation/DE-38M"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   } ],
   "extent" : [ "239 S. : zahlr. graph. Darst., Kt." ],
   "fulltextOnline" : [ {
-    "@id" : "http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=6326817&custom_att_2=simple_viewer"
+    "id" : "http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=6326817&custom_att_2=simple_viewer"
   } ],
   "hasVersion" : [ {
-    "@id" : "http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=6326817&custom_att_2=simple_viewer"
+    "id" : "http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=6326817&custom_att_2=simple_viewer"
   } ],
   "hbzId" : [ "HT018700720" ],
+  "id" : "http://lobid.org/resource/HT018700720",
   "inSeries" : [ {
     "numbering" : "47",
     "series" : [ {
-      "@id" : "http://lobid.org/resource/HT015550020"
+      "id" : "http://lobid.org/resource/HT015550020"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/lobid/lv#SeriesRelation"
-    } ]
+    "type" : [ "http://purl.org/lobid/lv#SeriesRelation" ]
   } ],
   "isPartOf" : [ {
-    "@id" : "http://lobid.org/resource/HT015550020"
+    "id" : "http://lobid.org/resource/HT015550020"
   } ],
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT018700720"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT018700720"
   } ],
   "isbn" : [ "9783942816618" ],
   "issued" : [ "2015" ],
   "language" : [ {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
   } ],
   "medium" : [ {
-    "@id" : "http://rdvocab.info/termList/RDACarrierType/1018"
+    "id" : "http://rdvocab.info/termList/RDACarrierType/1018"
   }, {
-    "@id" : "http://rdvocab.info/termList/RDACarrierType/1010"
+    "id" : "http://rdvocab.info/termList/RDACarrierType/1010"
   } ],
   "otherTitleInformation" : [ "Expertise zur Lebenslage von Menschen im Alter Ã¼ber 80 Jahren" ],
   "placeOfPublication" : [ "KÃ¶ln" ],
   "publicationStatement" : [ "KÃ¶ln; BZgA; 2015" ],
   "publisher" : [ "BZgA" ],
   "sameAs" : [ {
-    "@id" : "http://hub.culturegraph.org/resource/HBZ-HT018700720"
+    "id" : "http://hub.culturegraph.org/resource/HBZ-HT018700720"
   } ],
   "similar" : [ {
-    "@id" : "http://dx.doi.org/10.4126/38m-006326817"
+    "id" : "http://dx.doi.org/10.4126/38m-006326817"
   } ],
   "statementOfResponsibility" : [ "Ludwig Amrhein ; Josefine Heusinger ; Kathrin Ottovay ; Birgit Wolter" ],
   "subject" : [ {
-    "@id" : "http://dewey.info/class/610/"
+    "id" : "http://dewey.info/class/610/"
   } ],
   "title" : [ "Die Hochaltrigen" ],
-  "type" : [ {
-    "@id" : "http://purl.org/lobid/lv#Miscellaneous"
-  }, {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  } ],
+  "type" : [ "http://purl.org/dc/terms/BibliographicResource", "http://purl.org/lobid/lv#Miscellaneous" ],
   "volume" : [ "47" ]
 }

--- a/src/test/resources/output/json/01872/HT018726005.json
+++ b/src/test/resources/output/json/01872/HT018726005.json
@@ -1,69 +1,65 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/HT018726005",
   "bibliographicCitation" : [ "K.West; 2006,1, S. 12-14 : Ill." ],
   "collectedBy" : [ {
-    "@id" : "http://lobid.org/resource/NWBib"
+    "id" : "http://lobid.org/resource/NWBib"
   } ],
   "containedIn" : [ {
-    "@id" : "http://lobid.org/resource/HT013878511"
+    "id" : "http://lobid.org/resource/HT013878511"
   } ],
   "contributorLabel" : [ "Hoff, Hans" ],
   "contributorOrder" : [ "http://d-nb.info/gnd/137538766" ],
   "coverage" : [ "Bielefeld" ],
   "creator" : [ {
-    "@id" : "http://d-nb.info/gnd/137538766",
+    "id" : "http://d-nb.info/gnd/137538766",
     "preferredName" : "Hoff, Hans",
     "preferredNameForThePerson" : "Hoff, Hans"
   } ],
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/HT018726005/about",
-    "dateCreated" : "20150813"
+    "dateCreated" : "20150813",
+    "id" : "http://lobid.org/resource/HT018726005/about"
   } ],
   "fulltextOnline" : [ {
-    "@id" : "http://www.bibliothek.uni-regensburg.de/ezeit/?2655603"
+    "id" : "http://www.bibliothek.uni-regensburg.de/ezeit/?2655603"
   } ],
   "hasVersion" : [ {
-    "@id" : "http://www.bibliothek.uni-regensburg.de/ezeit/?2655603"
+    "id" : "http://www.bibliothek.uni-regensburg.de/ezeit/?2655603"
   } ],
   "hbzId" : [ "HT018726005" ],
+  "id" : "http://lobid.org/resource/HT018726005",
   "isPartOf" : [ {
-    "@id" : "http://lobid.org/resource/HT013878511"
+    "id" : "http://lobid.org/resource/HT013878511"
   } ],
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT018726005"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT018726005"
   } ],
   "issued" : [ "2006" ],
   "language" : [ {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
   } ],
   "medium" : [ {
-    "@id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
+    "id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
   } ],
   "nwbibsubject" : [ {
-    "@id" : "http://purl.org/lobid/nwbib#s802080"
+    "id" : "http://purl.org/lobid/nwbib#s802080"
   } ],
   "otherTitleInformation" : [ "die Parallelwelten des Ingolf Lück" ],
   "placeOfPublication" : [ "Essen" ],
   "publicationStatement" : [ "2006; Essen" ],
   "sameAs" : [ {
-    "@id" : "http://hub.culturegraph.org/resource/HBZ-HT018726005"
+    "id" : "http://hub.culturegraph.org/resource/HBZ-HT018726005"
   } ],
   "seeAlso" : [ {
-    "@id" : "http://www.bibliothek.uni-regensburg.de/ezeit/?2655603"
+    "id" : "http://www.bibliothek.uni-regensburg.de/ezeit/?2655603"
   } ],
   "statementOfResponsibility" : [ "Text: Hans Hoff" ],
   "subject" : [ {
-    "@id" : "http://d-nb.info/gnd/128989459",
+    "id" : "http://d-nb.info/gnd/128989459",
     "preferredName" : "Lück, Ingolf",
     "preferredNameForThePerson" : "Lück, Ingolf"
   } ],
   "subjectChain" : [ "Lück, Ingolf" ],
   "subjectOrder" : [ "http://d-nb.info/gnd/128989459" ],
   "title" : [ "Eine Marke sucht ihren Platz" ],
-  "type" : [ {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  }, {
-    "@id" : "http://purl.org/ontology/bibo/Article"
-  } ]
+  "type" : [ "http://purl.org/ontology/bibo/Article", "http://purl.org/dc/terms/BibliographicResource" ]
 }

--- a/src/test/resources/output/json/01877/HT018770176.json
+++ b/src/test/resources/output/json/01877/HT018770176.json
@@ -1,91 +1,79 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/HT018770176",
   "contributorLabel" : [ "Stahl, Dominik" ],
   "contributorOrder" : [ "http://d-nb.info/gnd/1042242615" ],
   "creator" : [ {
-    "@id" : "http://d-nb.info/gnd/1042242615",
+    "id" : "http://d-nb.info/gnd/1042242615",
     "preferredName" : "Stahl, Dominik",
     "preferredNameForThePerson" : "Stahl, Dominik"
   } ],
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/HT018770176/about"
+    "id" : "http://lobid.org/resource/HT018770176/about"
   } ],
   "edition" : [ "[1. Aufl.]" ],
   "exemplar" : [ {
-    "@id" : "http://lobid.org/item/HT018770176:DE-294-39:123%2FY%2F3264",
     "callNumber" : "123/Y/3264",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT018770176:DE-294-39:123%2FY%2F3264/about"
+      "id" : "http://lobid.org/item/HT018770176:DE-294-39:123%2FY%2F3264/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT018770176",
+    "id" : "http://lobid.org/item/HT018770176:DE-294-39:123%2FY%2F3264",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-294-39"
+      "id" : "http://lobid.org/organisation/DE-294-39"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   }, {
-    "@id" : "http://lobid.org/item/HT018770176:DE-6-228:StrR%20XIV%2023%2F246",
     "callNumber" : "StrR XIV 23/246",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT018770176:DE-6-228:StrR%20XIV%2023%2F246/about"
+      "id" : "http://lobid.org/item/HT018770176:DE-6-228:StrR%20XIV%2023%2F246/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT018770176",
+    "id" : "http://lobid.org/item/HT018770176:DE-6-228:StrR%20XIV%2023%2F246",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-6-228"
+      "id" : "http://lobid.org/organisation/DE-6-228"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   } ],
   "extent" : [ "276 S." ],
   "hbzId" : [ "HT018770176" ],
+  "id" : "http://lobid.org/resource/HT018770176",
   "inSeries" : [ {
     "numbering" : "Neue Folge, Band 264",
     "series" : [ {
-      "@id" : "http://lobid.org/resource/HT001252640"
+      "id" : "http://lobid.org/resource/HT001252640"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/lobid/lv#SeriesRelation"
-    } ]
+    "type" : [ "http://purl.org/lobid/lv#SeriesRelation" ]
   } ],
   "isPartOf" : [ {
-    "@id" : "http://lobid.org/resource/HT001252640"
+    "id" : "http://lobid.org/resource/HT001252640"
   } ],
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT018770176"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT018770176"
   } ],
   "isbn" : [ "9783428147335", "3428147332" ],
   "issued" : [ "2015" ],
   "language" : [ {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
   } ],
   "medium" : [ {
-    "@id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
+    "id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
   } ],
   "otherTitleInformation" : [ "zugleich ein Beitrag zur Strafzumessungsrelevanz des Vor- und Nachtatverhaltens" ],
   "placeOfPublication" : [ "Berlin" ],
   "publicationStatement" : [ "Berlin; Duncker & Humblot; 2015" ],
   "publisher" : [ "Duncker & Humblot" ],
   "sameAs" : [ {
-    "@id" : "http://hub.culturegraph.org/resource/HBZ-HT018770176"
+    "id" : "http://hub.culturegraph.org/resource/HBZ-HT018770176"
   } ],
   "statementOfResponsibility" : [ "von Dominik Stahl" ],
   "subject" : [ {
-    "@id" : "http://dewey.info/class/340/"
+    "id" : "http://dewey.info/class/340/"
   } ],
   "tableOfContents" : [ {
-    "@id" : "http://d-nb.info/1076583180/04"
+    "id" : "http://d-nb.info/1076583180/04"
   } ],
   "thesisInformation" : [ "Albert-Ludwigs-Universität Freiburg, Dissertation, 2014/2015" ],
   "title" : [ "Strafzumessungstatsachen zwischen Verbrechenslehre und Straftheorie" ],
-  "type" : [ {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  }, {
-    "@id" : "http://purl.org/ontology/bibo/Thesis"
-  }, {
-    "@id" : "http://purl.org/ontology/bibo/Book"
-  } ],
+  "type" : [ "http://purl.org/ontology/bibo/Book", "http://purl.org/dc/terms/BibliographicResource", "http://purl.org/ontology/bibo/Thesis" ],
   "volume" : [ "Neue Folge, Band 264" ]
 }

--- a/src/test/resources/output/json/01877/HT018771475.json
+++ b/src/test/resources/output/json/01877/HT018771475.json
@@ -1,11 +1,10 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/HT018771475",
   "collectedBy" : [ {
-    "@id" : "http://lobid.org/resource/NWBib"
+    "id" : "http://lobid.org/resource/NWBib"
   } ],
   "contributor" : [ {
-    "@id" : "http://d-nb.info/gnd/102654520X",
+    "id" : "http://d-nb.info/gnd/102654520X",
     "preferredName" : "Rösgen, Anya",
     "preferredNameForThePerson" : "Rösgen, Anya"
   } ],
@@ -13,56 +12,51 @@
   "contributorOrder" : [ "http://d-nb.info/gnd/102654520X | http://d-nb.info/gnd/1074109953" ],
   "coverage" : [ "Bergisch Gladbach- Bensberg" ],
   "creator" : [ {
-    "@id" : "http://d-nb.info/gnd/1074109953",
+    "id" : "http://d-nb.info/gnd/1074109953",
     "preferredName" : "7. Schloss Bensberg Classics, 2015, Bergisch Gladbach"
   } ],
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/HT018771475/about",
-    "dateCreated" : "20151005"
+    "dateCreated" : "20151005",
+    "id" : "http://lobid.org/resource/HT018771475/about"
   } ],
   "extent" : [ "42 S." ],
   "hbzId" : [ "HT018771475" ],
+  "id" : "http://lobid.org/resource/HT018771475",
   "isPartOfName" : [ "Classic cars" ],
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT018771475"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT018771475"
   } ],
   "issued" : [ "2015" ],
   "language" : [ {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
   } ],
   "medium" : [ {
-    "@id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
+    "id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
   } ],
   "nwbibsubject" : [ {
-    "@id" : "http://purl.org/lobid/nwbib#s733030"
+    "id" : "http://purl.org/lobid/nwbib#s733030"
   } ],
   "otherTitleInformation" : [ "17. bis 19. Juli 2015" ],
   "placeOfPublication" : [ "Hamburg" ],
   "publicationStatement" : [ "Hamburg; Bauer; 2015" ],
   "publisher" : [ "Bauer" ],
   "sameAs" : [ {
-    "@id" : "http://hub.culturegraph.org/resource/HBZ-HT018771475"
+    "id" : "http://hub.culturegraph.org/resource/HBZ-HT018771475"
   } ],
   "statementOfResponsibility" : [ "[Text Anya Rösgen ; Hans-Joachim Wiehager]" ],
   "subject" : [ {
-    "@id" : "http://dewey.info/class/796/"
+    "id" : "http://dewey.info/class/796/"
   }, {
-    "@id" : "http://d-nb.info/gnd/1074109953",
+    "id" : "http://d-nb.info/gnd/1074109953",
     "preferredName" : "7. Schloss Bensberg Classics, 2015, Bergisch Gladbach"
   } ],
   "subjectChain" : [ "Bergisch Gladbach | Bildband" ],
   "subjectLabel" : [ "7. Schloss Bensberg Classics" ],
   "subjectOrder" : [ "http://d-nb.info/gnd/1074109953, Bildband" ],
   "tableOfContents" : [ {
-    "@id" : "http://d-nb.info/1074113608/04"
+    "id" : "http://d-nb.info/1074113608/04"
   } ],
   "title" : [ "7. Schloss Bensberg Classics" ],
-  "type" : [ {
-    "@id" : "http://purl.org/ontology/bibo/Proceedings"
-  }, {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  }, {
-    "@id" : "http://purl.org/ontology/bibo/Book"
-  } ],
+  "type" : [ "http://purl.org/ontology/bibo/Book", "http://purl.org/dc/terms/BibliographicResource", "http://purl.org/ontology/bibo/Proceedings" ],
   "volume" : [ "[2015,8, Beil.]" ]
 }

--- a/src/test/resources/output/json/01877/HT018779822.json
+++ b/src/test/resources/output/json/01877/HT018779822.json
@@ -1,54 +1,48 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/HT018779822",
   "contributorLabel" : [ "Cross, Julie" ],
   "contributorOrder" : [ "http://d-nb.info/gnd/143846655" ],
   "creator" : [ {
-    "@id" : "http://d-nb.info/gnd/143846655",
+    "id" : "http://d-nb.info/gnd/143846655",
     "preferredName" : "Cross, Julie",
     "preferredNameForThePerson" : "Cross, Julie"
   } ],
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/HT018779822/about",
-    "dateCreated" : "20151014"
+    "dateCreated" : "20151014",
+    "id" : "http://lobid.org/resource/HT018779822/about"
   } ],
   "exemplar" : [ {
-    "@id" : "http://lobid.org/item/HT018779822:DE-Kob7:",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT018779822:DE-Kob7:/about"
+      "id" : "http://lobid.org/item/HT018779822:DE-Kob7:/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT018779822",
+    "id" : "http://lobid.org/item/HT018779822:DE-Kob7:",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-Kob7"
+      "id" : "http://lobid.org/organisation/DE-Kob7"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   } ],
   "extent" : [ "264 Seiten" ],
   "hbzId" : [ "HT018779822" ],
+  "id" : "http://lobid.org/resource/HT018779822",
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT018779822"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT018779822"
   } ],
   "isbn" : [ "9781138816503" ],
   "issued" : [ "2014" ],
   "language" : [ {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/eng"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/eng"
   } ],
   "medium" : [ {
-    "@id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
+    "id" : "http://rdvocab.info/termList/RDAproductionMethod/1010"
   } ],
   "placeOfPublication" : [ "New York" ],
   "publicationStatement" : [ "New York; Routledge; 2014" ],
   "publisher" : [ "Routledge" ],
   "sameAs" : [ {
-    "@id" : "http://hub.culturegraph.org/resource/HBZ-HT018779822"
+    "id" : "http://hub.culturegraph.org/resource/HBZ-HT018779822"
   } ],
   "statementOfResponsibility" : [ "Julie Cross" ],
   "title" : [ "Humor in contemporary junior literature" ],
-  "type" : [ {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  }, {
-    "@id" : "http://purl.org/ontology/bibo/Book"
-  } ]
+  "type" : [ "http://purl.org/ontology/bibo/Book", "http://purl.org/dc/terms/BibliographicResource" ]
 }

--- a/src/test/resources/output/json/01880/HT018801101.json
+++ b/src/test/resources/output/json/01880/HT018801101.json
@@ -1,74 +1,68 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
-  "@id" : "http://lobid.org/resource/HT018801101",
   "contributorLabel" : [ "Roesner, Elke", "Kullmer, Bettina", "Schmitz, Jasmin", "Arning, Ursula" ],
   "contributorName" : [ "Schmitz, Jasmin" ],
   "contributorOrder" : [ "http://d-nb.info/gnd/1072011352 | Kullmer, Bettina | http://d-nb.info/gnd/1049793021 | Schmitz, Jasmin" ],
   "creator" : [ {
-    "@id" : "http://d-nb.info/gnd/1072011352",
+    "id" : "http://d-nb.info/gnd/1072011352",
     "preferredName" : "Arning, Ursula",
     "preferredNameForThePerson" : "Arning, Ursula"
   }, {
-    "@id" : "http://d-nb.info/gnd/1049793021",
+    "id" : "http://d-nb.info/gnd/1049793021",
     "preferredName" : "Roesner, Elke",
     "preferredNameForThePerson" : "Roesner, Elke"
   } ],
   "creatorName" : [ "Kullmer, Bettina" ],
   "describedby" : [ {
-    "@id" : "http://lobid.org/resource/HT018801101/about",
     "dateCreated" : "20151109",
-    "dateModified" : "20151203"
+    "dateModified" : "20151203",
+    "id" : "http://lobid.org/resource/HT018801101/about"
   } ],
   "doi" : [ "10.4126/FRL01-006399387" ],
   "exemplar" : [ {
-    "@id" : "http://lobid.org/item/HT018801101:DE-38M:Elektronische%20Publikation",
     "callNumber" : "Elektronische Publikation",
     "describedby" : [ {
-      "@id" : "http://lobid.org/item/HT018801101:DE-38M:Elektronische%20Publikation/about"
+      "id" : "http://lobid.org/item/HT018801101:DE-38M:Elektronische%20Publikation/about"
     } ],
     "exemplarOf" : "http://lobid.org/resource/HT018801101",
+    "id" : "http://lobid.org/item/HT018801101:DE-38M:Elektronische%20Publikation",
     "owner" : [ {
-      "@id" : "http://lobid.org/organisation/DE-38M"
+      "id" : "http://lobid.org/organisation/DE-38M"
     } ],
-    "type" : [ {
-      "@id" : "http://purl.org/vocab/frbr/core#Item"
-    } ]
+    "type" : [ "http://purl.org/vocab/frbr/core#Item" ]
   } ],
   "extent" : [ "1 Online-Ressource (1 Videodatei)" ],
   "hbzId" : [ "HT018801101" ],
+  "id" : "http://lobid.org/resource/HT018801101",
   "isPrimaryTopicOf" : [ {
-    "@id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT018801101"
+    "id" : "http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT018801101"
   } ],
   "issued" : [ "2015" ],
   "language" : [ {
-    "@id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/deu"
   } ],
   "medium" : [ {
-    "@id" : "http://rdvocab.info/termList/RDACarrierType/1018"
+    "id" : "http://rdvocab.info/termList/RDACarrierType/1018"
   }, {
-    "@id" : "http://rdvocab.info/termList/RDACarrierType/1050"
+    "id" : "http://rdvocab.info/termList/RDACarrierType/1050"
   }, {
-    "@id" : "http://purl.org/ontology/bibo/AudioVisualDocument"
+    "id" : "http://purl.org/ontology/bibo/AudioVisualDocument"
   }, {
-    "@id" : "http://rdvocab.info/termList/RDACarrierType/1010"
+    "id" : "http://rdvocab.info/termList/RDACarrierType/1010"
   } ],
   "placeOfPublication" : [ "Köln" ],
   "publicationStatement" : [ "Köln; ZB MED - Leibniz-Informationszentrum Lebenswissenschaften; 2015" ],
   "publisher" : [ "ZB MED - Leibniz-Informationszentrum Lebenswissenschaften" ],
   "sameAs" : [ {
-    "@id" : "http://hub.culturegraph.org/resource/HBZ-HT018801101"
+    "id" : "http://hub.culturegraph.org/resource/HBZ-HT018801101"
   } ],
   "similar" : [ {
-    "@id" : "http://dx.doi.org/10.4126/FRL01-006399387"
+    "id" : "http://dx.doi.org/10.4126/FRL01-006399387"
   } ],
   "statementOfResponsibility" : [ "[Konzeption und Redaktion: Ursula Arning, Bettina Kullmer, Elke Roesner ; Mitarbeit: Jasmin Schmitz]" ],
   "subject" : [ {
-    "@id" : "http://dewey.info/class/610/"
+    "id" : "http://dewey.info/class/610/"
   } ],
   "title" : [ "PUBLISSO - Das ZB MED Open-Access-Publikationsportal" ],
-  "type" : [ {
-    "@id" : "http://purl.org/lobid/lv#Miscellaneous"
-  }, {
-    "@id" : "http://purl.org/dc/terms/BibliographicResource"
-  } ]
+  "type" : [ "http://purl.org/dc/terms/BibliographicResource", "http://purl.org/lobid/lv#Miscellaneous" ]
 }


### PR DESCRIPTION
Resolves #29.

Mapping "type" to "@type/@id" in the context does two things:
1.  forces the usage of strings in the "type" field (while, in fact, being
   objects (aka: resources) when parsed with an json-ld library).
2. takes the burden of having `@` in field names
