### PR TITLE
Release 0.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>de.hbz.lobid</groupId>
   <artifactId>lobid-rdf-to-json</artifactId>
-  <version>0.0.2-SNAPSHOT</version>
+  <version>0.0.2</version>
   <properties>
     <logback.version>0.9.30</logback.version>
     <slf4j.version>1.6.2</slf4j.version>


### PR DESCRIPTION
Releases version 0.0.2. Can then be easily configured by e.g. `lobid-resources` in pom.xml to be used as maven dependency, using [jitpack](https://jitpack.io/).
