### PR TITLE
Take repeating rdf predicates into account

### DIFF
--- a/src/main/java/de/hbz/lobid/helper/JsonConverter.java
+++ b/src/main/java/de/hbz/lobid/helper/JsonConverter.java
@@ -269,7 +269,20 @@ public class JsonConverter {
 		for (Statement s : find(uri)) {
 			Etikett e = etikette.getEtikett(s.getPredicate().stringValue());
 			if (s.getObject() instanceof org.openrdf.model.Literal) {
-				newObject.put(e.name, s.getObject().stringValue());
+				if (newObject.containsKey(e.name)) {
+					Object existingValue = newObject.get(e.name);
+					if (existingValue instanceof String) {
+						Set<String> icanmany = new HashSet<String>();
+						icanmany.add((String) existingValue);
+						icanmany.add(s.getObject().stringValue());
+						newObject.put(e.name, icanmany);
+					} else {
+						((Set<String>) existingValue).add(s.getObject().stringValue());
+					}
+
+				} else {
+					newObject.put(e.name, s.getObject().stringValue());
+				}
 			} else {
 				if (statementVisited(s)) {
 					continue;

--- a/src/main/resources/labels.json
+++ b/src/main/resources/labels.json
@@ -8,6 +8,13 @@
 		"uri":"@type"
 	},
 	{
+		"name": "altLabel",
+		"uri":"http://www.w3.org/2004/02/skos/core#altLabel",
+		"label":"Alternative Bezeichnung",
+		"referenceType":"String",
+		"container":"@set"
+	},
+	{
 		"name": "longitudeAndLatitude",
 		"uri":"http://rdaregistry.info/Elements/u/P60345",
 		"label":"Geokoordinaten",

--- a/src/test/resources/input/nt/00000/BT000002852.nt
+++ b/src/test/resources/input/nt/00000/BT000002852.nt
@@ -1,3 +1,7 @@
+<http://d-nb.info/gnd/4018466-3> <http://www.w3.org/2004/02/skos/core#altLabel> "Freudenberg, Kreis Siegen-Wittgenstein" .
+<http://d-nb.info/gnd/4018466-3> <http://www.w3.org/2004/02/skos/core#altLabel> "Freudenberg" .
+<http://d-nb.info/gnd/4018466-3> <http://www.w3.org/2004/02/skos/core#altLabel> "Freudenberg (Siegerland)" .
+<http://d-nb.info/gnd/4018466-3> <http://www.w3.org/2004/02/skos/core#altLabel> "Stadt Freudenberg S\u00FCdwestfalen" .
 <http://d-nb.info/gnd/4018466-3> <http://d-nb.info/standards/elementset/gnd#preferredName> "Freudenberg, Kreis Siegen-Wittgenstein" .
 <http://d-nb.info/gnd/4018466-3> <http://d-nb.info/standards/elementset/gnd#preferredNameForThePlaceOrGeographicName> "Freudenberg" .
 <http://d-nb.info/gnd/4020517-4> <http://d-nb.info/standards/elementset/gnd#preferredNameForTheSubjectHeading> "Geschichte" .

--- a/src/test/resources/output/json/00000/BT000002852.json
+++ b/src/test/resources/output/json/00000/BT000002852.json
@@ -6,6 +6,7 @@
   "contributorOrder" : [ "http://d-nb.info/gnd/4018466-3" ],
   "coverage" : [ "Freudenberg <Siegen-Wittgenstein>" ],
   "creator" : [ {
+    "altLabel" : [ "Freudenberg", "Freudenberg (Siegerland)", "Stadt Freudenberg Südwestfalen", "Freudenberg, Kreis Siegen-Wittgenstein" ],
     "id" : "http://d-nb.info/gnd/4018466-3",
     "preferredName" : "Freudenberg, Kreis Siegen-Wittgenstein",
     "preferredNameForThePlaceOrGeographicName" : "Freudenberg"
@@ -36,13 +37,14 @@
   } ],
   "statementOfResponsibility" : [ "[Hrsg.: Stadt Freudenberg, Der Stadtdirektor]" ],
   "subject" : [ {
-    "id" : "http://d-nb.info/gnd/4020517-4",
-    "preferredName" : "Geschichte",
-    "preferredNameForTheSubjectHeading" : "Geschichte"
-  }, {
+    "altLabel" : [ "Freudenberg", "Freudenberg (Siegerland)", "Stadt Freudenberg Südwestfalen", "Freudenberg, Kreis Siegen-Wittgenstein" ],
     "id" : "http://d-nb.info/gnd/4018466-3",
     "preferredName" : "Freudenberg, Kreis Siegen-Wittgenstein",
     "preferredNameForThePlaceOrGeographicName" : "Freudenberg"
+  }, {
+    "id" : "http://d-nb.info/gnd/4020517-4",
+    "preferredName" : "Geschichte",
+    "preferredNameForTheSubjectHeading" : "Geschichte"
   } ],
   "subjectChain" : [ "Freudenberg | Kreis Siegen-Wittgenstein | Geschichte" ],
   "subjectLabel" : [ "Freudenberg Siegen", "Landesgeschichte", "Freudenberg (Siegerland)", "Ortsgeschichte", "Stadt Freudenberg", "Zeitgeschichte", "Stadt Freudenberg Südwestfalen", "Regionalgeschichte" ],


### PR DESCRIPTION
- in case of repeating predicates generate a set to store
  all repeating values under the same json key
  e.g. converts

```
<_:1> <lv:altLabel> "l1".
<_:1> <lv:altLabel> "l2".
<_:1> <lv:altLabel> "l3".
```

to json

```
"@id":"_:1",
"altLabel":["l1","l2","l3"]
```
