### PR TITLE
remove context creation from constructor

### DIFF
--- a/src/main/java/de/hbz/lobid/helper/EtikettMaker.java
+++ b/src/main/java/de/hbz/lobid/helper/EtikettMaker.java
@@ -75,7 +75,6 @@ public class EtikettMaker implements EtikettMakerInterface {
 	public EtikettMaker(InputStream labelIn) {
 		initMaps(labelIn);
 		initContext();
-		writeContext();
 	}
 
 	/*
@@ -111,7 +110,7 @@ public class EtikettMaker implements EtikettMakerInterface {
 		context = createContext();
 	}
 
-	private void writeContext() {
+	public void writeContext() {
 		logger.info("Writing context file ...");
 		try {
 			JsonConverter.getObjectMapper().defaultPrettyPrintingWriter()

--- a/src/test/java/TestGenerateContext.java
+++ b/src/test/java/TestGenerateContext.java
@@ -1,0 +1,19 @@
+import org.junit.Test;
+
+import de.hbz.lobid.helper.EtikettMaker;
+
+/**
+ * 
+ * @author Jan Schnasse
+ *
+ */
+
+@SuppressWarnings("javadoc")
+public class TestGenerateContext {
+
+	@Test
+	public void writeContext() {
+		new EtikettMaker(Thread.currentThread().getContextClassLoader()
+				.getResourceAsStream("labels.json")).writeContext();
+	}
+}


### PR DESCRIPTION
- writing out the context is logically not part of object construction and should be separated
- makes the EtikettMaker more reusable (e.g. when used in library).
- current code fails in play project regal-api because of context creation
