### PR TITLE
Add bibo:Image; add context creating test class to UniTests

### DIFF
--- a/src/main/resources/labels.json
+++ b/src/main/resources/labels.json
@@ -11758,6 +11758,14 @@
         "multilangLabel": { }
     },
     {
+        "uri": "http://purl.org/ontology/bibo/Image",
+        "label": "Bild",
+        "name": "image",
+        "referenceType": "String",
+        "container": "@set",
+        "multilangLabel": { }
+    },
+    {
         "uri": "http://purl.org/ontology/bibo/edition",
         "label": "Auflage",
         "name": "edition",

--- a/src/test/java/UnitTests.java
+++ b/src/test/java/UnitTests.java
@@ -12,7 +12,7 @@ import org.junit.runners.Suite;
  */
 @RunWith(Suite.class)
 @Suite.SuiteClasses({ TestRdfToJsonConversion.class,
-		TestJsonToRdfConversion.class })
+		TestJsonToRdfConversion.class, TestGenerateContext.class })
 public final class UnitTests {
 	/* Suite class, groups tests via annotation above */
 }


### PR DESCRIPTION
Somehow in hbz/lobid-resources/commit/785bdf8f5ea74b1482e97b01800c2104c7d5373e
the bibo:Image was introduced but forgotten to config the labels.json.
Further, the context creating test class was not part of the executing
UnitTests.class and thus a context was never produced.